### PR TITLE
Fix wasm-gc dependency error in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,10 @@ env:
   global:
     - CRATE_NAME=chainx
 
-matrix:
-  include:
-    - env: TARGET=x86_64-unknown-linux-gnu
+# Ignore the various targets for now
+# matrix:
+  # include:
+    # - env: TARGET=x86_64-unknown-linux-gnu
 
 before_install:
   - set -e
@@ -24,7 +25,7 @@ before_install:
   - rustup update nightly
   - rustup target add wasm32-unknown-unknown --toolchain nightly
   - rustup update stable
-  - cargo install --git https://github.com/alexcrichton/wasm-gc
+  - cargo install --git https://github.com/alexcrichton/wasm-gc --force
   - sudo apt update
   - sudo apt install -y pkg-config libssl-dev
   - sudo bash ci/cmake.sh 3.5.1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ChainX
 
+[![Build Status](https://travis-ci.com/chainx-org/ChainX.svg?branch=master)](https://travis-ci.com/chainx-org/ChainX)
+
 <!-- TOC GFM -->
 
 * [Introduction](#introduction)
@@ -57,8 +59,11 @@ $ sudo apt install cmake pkg-config libssl-dev git
 $ git clone https://github.com/chainx-org/ChainX ~/ChainX
 $ cd ~/ChainX
 
-# Build all native code
+# Build all native code, the executable binary will be present in target/debug/chainx.
 $ cargo build
+
+# If your want to run chainx in production, please build it in release mode
+$ cargo build --release
 ```
 
 ## Development


### PR DESCRIPTION
- add `--force` option rudely
- ingore the building for various targets for now until the release via
CI is complete.