### PR TITLE
Create Memo struct and remove unused types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,6 +513,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-std",
+ "xrml-support",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,8 +506,10 @@ dependencies = [
 name = "chainx-primitives"
 version = "2.0.0"
 dependencies = [
+ "anyhow",
  "frame-system",
  "parity-scale-codec",
+ "serde",
  "sp-application-crypto",
  "sp-core",
  "sp-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,7 +506,6 @@ dependencies = [
 name = "chainx-primitives"
 version = "2.0.0"
 dependencies = [
- "anyhow",
  "frame-system",
  "parity-scale-codec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,5 +42,5 @@ substrate-build-script-utils = { git = "https://github.com/paritytech/substrate.
 
 [workspace]
 members = [
-    "runtime"
+    "runtime",
 ]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](./LICENSE)
 [![CI](https://github.com/chainx-org/ChainX/workflows/ci/badge.svg)](https://github.com/chainx-org/ChainX/actions?workflow=ci)
-[![WASM](https://github.com/chainx-org/ChainX/workflows/wasm/badge.svg)](https://github.com/chainx-org/ChainX/actions?workflow=wasm)
 
 [ChainX](https://github.com/chainx-org/ChainX) is a community-driven project built on the next-generation blockchain framework [substrate](https://github.com/paritytech/substrate), the largest Layer-2 network of Bitcoin using the Light-client protocol with smart contract support, will evolve into the Polkadot network as a secondary relay chain in the future.
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -5,7 +5,9 @@ authors = ["ChainX community <http://www.chainx.org>"]
 edition = "2018"
 
 [dependencies]
+anyhow = { version = "1.0", default-features = false }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
+serde = { version = "1.0.101", optional = true, features = ["derive"] }
 
 sp-std = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
@@ -17,7 +19,9 @@ frame-system = { git = "https://github.com/paritytech/substrate.git", tag = "v2.
 [features]
 default = ["std"]
 std = [
+    "anyhow/std",
     "codec/std",
+    "serde/std",
 
     "sp-std/std",
     "sp-runtime/std",

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -17,6 +17,9 @@ sp-std = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc
 # Substrate pallets
 frame-system = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 
+# ChainX pallets
+xrml-support = { path = "../xrml/support", default-features = false }
+
 [features]
 default = ["std"]
 std = [
@@ -29,4 +32,6 @@ std = [
     "sp-std/std",
 
     "frame-system/std",
+
+    "xrml-support/std",
 ]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -9,11 +9,13 @@ anyhow = { version = "1.0", default-features = false }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 
-sp-std = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
+# Substrate primitives
 sp-application-crypto = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 
+# Substrate pallets
 frame-system = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 
 [features]
@@ -23,10 +25,10 @@ std = [
     "codec/std",
     "serde/std",
 
-    "sp-std/std",
-    "sp-runtime/std",
-    "sp-core/std",
     "sp-application-crypto/std",
+    "sp-core/std",
+    "sp-runtime/std",
+    "sp-std/std",
 
     "frame-system/std",
 ]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["ChainX community <http://www.chainx.org>"]
 edition = "2018"
 
 [dependencies]
-anyhow = { version = "1.0", default-features = false }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 
@@ -21,7 +20,6 @@ frame-system = { git = "https://github.com/paritytech/substrate.git", tag = "v2.
 [features]
 default = ["std"]
 std = [
-    "anyhow/std",
     "codec/std",
     "serde/std",
 

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -75,6 +75,14 @@ impl From<&[u8]> for Memo {
     }
 }
 
+#[cfg(feature = "std")]
+impl std::fmt::Display for Memo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", String::from_utf8_lossy(&self.0))
+    }
+}
+
+#[cfg(not(feature = "std"))]
 impl core::fmt::Display for Memo {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:?}", self.0)

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -3,7 +3,7 @@
 use sp_runtime::{
     generic,
     traits::{BlakeTwo256, IdentifyAccount, Verify},
-    MultiSignature, OpaqueExtrinsic,
+    DispatchError, DispatchResult, MultiSignature, OpaqueExtrinsic,
 };
 use sp_std::prelude::Vec;
 
@@ -85,10 +85,10 @@ const MAXIMUM_MEMO_LEN: u8 = 128;
 
 impl Memo {
     /// Returns true if the byte length is in the range of [0, 128].
-    pub fn check_validity(&self) -> anyhow::Result<()> {
+    pub fn check_validity(&self) -> DispatchResult {
         if self.0.len() > MAXIMUM_MEMO_LEN as usize {
-            Err(anyhow::anyhow!(
-                "transaction memo too long, the range of valid byte length: [0, 128]"
+            Err(DispatchError::Other(
+                "transaction memo too long, the range of valid byte length: [0, 128]",
             ))
         } else {
             Ok(())

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -50,11 +50,8 @@ pub type BlockId = generic::BlockId<Block>;
 /// String for Runtime
 pub type Text = Vec<u8>;
 pub type Desc = Vec<u8>;
-// pub type Memo = Vec<u8>;
 pub type Token = Vec<u8>;
 pub type Precision = u8;
-pub type Name = Vec<u8>;
-pub type URL = Vec<u8>;
 pub type AddrStr = Vec<u8>;
 pub type AssetId = u32;
 

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -99,7 +99,7 @@ impl Memo {
                 "transaction memo too long, the range of valid byte length: [0, 128]",
             ))
         } else {
-            Ok(())
+            xrml_support::xss_check(&self.0)
         }
     }
 }

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -39,10 +39,13 @@ pub type Timestamp = u64;
 
 /// Digest item type.
 pub type DigestItem = generic::DigestItem<Hash>;
+
 /// Header type.
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
+
 /// Block type.
 pub type Block = generic::Block<Header, OpaqueExtrinsic>;
+
 /// Block ID.
 pub type BlockId = generic::BlockId<Block>;
 

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -92,7 +92,7 @@ impl core::fmt::Display for Memo {
 const MAXIMUM_MEMO_LEN: u8 = 128;
 
 impl Memo {
-    /// Returns true if the byte length is in the range of [0, 128].
+    /// Returns true if the inner byte length is in the range of [0, 128] and passes the xss check.
     pub fn check_validity(&self) -> DispatchResult {
         if self.0.len() > MAXIMUM_MEMO_LEN as usize {
             Err(DispatchError::Other(

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -50,13 +50,52 @@ pub type BlockId = generic::BlockId<Block>;
 /// String for Runtime
 pub type Text = Vec<u8>;
 pub type Desc = Vec<u8>;
-pub type Memo = Vec<u8>;
+// pub type Memo = Vec<u8>;
 pub type Token = Vec<u8>;
 pub type Precision = u8;
 pub type Name = Vec<u8>;
 pub type URL = Vec<u8>;
 pub type AddrStr = Vec<u8>;
 pub type AssetId = u32;
+
+/// Type for leaving a note when sending a transaction.
+#[derive(PartialEq, Eq, Clone, sp_core::RuntimeDebug, codec::Encode, codec::Decode)]
+#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+pub struct Memo(Vec<u8>);
+
+impl From<Vec<u8>> for Memo {
+    fn from(raw: Vec<u8>) -> Self {
+        Self(raw)
+    }
+}
+
+impl From<&[u8]> for Memo {
+    fn from(raw: &[u8]) -> Self {
+        Self(raw.to_vec())
+    }
+}
+
+impl core::fmt::Display for Memo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
+
+const MAXIMUM_MEMO_LEN: u8 = 128;
+
+impl Memo {
+    /// Returns true if the byte length is in the range of [0, 128].
+    pub fn check_validity(&self) -> anyhow::Result<()> {
+        if self.0.len() > MAXIMUM_MEMO_LEN as usize {
+            Err(anyhow::anyhow!(
+                "transaction memo too long, the range of valid byte length: [0, 128]"
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
 /// App-specific crypto used for reporting equivocation/misbehavior in BABE and
 /// GRANDPA. Any rewards for misbehavior reporting will be paid out to this
 /// account.

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -12,9 +12,11 @@ jsonrpc-derive = "14.0.3"
 serde_json = "1.0"
 hex = "0.4"
 
+# Substrate client
 sc-service = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", features = ["test-helpers"] }
 sc-client-api = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3" }
 
+# Substrate utils
 substrate-frame-rpc-system = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3" }
 
 # Substrate primitives

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -14,21 +14,26 @@ hex = "0.4"
 
 sc-service = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", features = ["test-helpers"] }
 sc-client-api = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3" }
+
+substrate-frame-rpc-system = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3" }
+
+# Substrate primitives
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3" }
 sp-consensus = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3" }
 sp-api = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3" }
 sp-transaction-pool = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3" }
 sp-blockchain = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3" }
 sp-state-machine = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3" }
+
+# Substrate pallets
 frame-support = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3" }
 
-substrate-frame-rpc-system = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3" }
+chainx-runtime = { path = "../runtime" }
 
+# ChainX primitives
+chainx-primitives = { path = "../primitives" }
+
+# ChainX pallets
 xrml-contracts-rpc = { path = "../xrml/contracts/rpc" }
 xrml-contracts-rpc-runtime-api = { path = "../xrml/contracts/rpc/runtime-api" }
 xrml-transaction-payment-rpc = { path = "../xrml/transaction-payment/rpc" }
-
-chainx-primitives = { path = "../primitives" }
-chainx-runtime = { path = "../runtime" }
-
-

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -11,6 +11,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 
+# Substrate primitives
 sp-io = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 sp-core = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
@@ -24,19 +25,21 @@ sp-block-builder = { git = "https://github.com/paritytech/substrate.git", tag = 
 sp-consensus-aura = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 sp-transaction-pool = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 
+# Substrate pallets
 frame-support = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 frame-system = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 frame-executive = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
-
 pallet-aura = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 pallet-grandpa = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 pallet-sudo = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 
+# ChainX primitives
 chainx-primitives = { path = "../primitives", default-features = false }
 
+# ChainX pallets
 xrml-assets = { path = "../xrml/assets", default-features = false }
 xrml-bridge-bitcoin = { path = "../xrml/bridge/bitcoin", default-features = false }
 xrml-contracts = { path = "../xrml/contracts", default-features = false }

--- a/xrml/assets/Cargo.toml
+++ b/xrml/assets/Cargo.toml
@@ -8,16 +8,20 @@ edition = "2018"
 serde = { version = "1.0", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", features = ["derive"], default-features = false }
 bitmask = { version = "0.5.0", default-features = false }
-# substrate
+
+# Substrate primitives
 sp-std = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 sp-core = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
-# substrate runtime module
+
+# Substrate pallets
 frame-support = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 frame-system = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
-# chainx
+
+# ChainX primitives
 chainx-primitives = { path = "../../primitives", default-features = false }
-# xrml
+
+# ChainX pallets
 xrml-protocol = { path = "../protocol", default-features = false }
 xrml-support = { path = "../support", default-features = false }
 

--- a/xrml/assets/src/lib.rs
+++ b/xrml/assets/src/lib.rs
@@ -200,7 +200,7 @@ decl_module! {
         pub fn transfer(origin, dest: T::AccountId, #[compact] id: AssetId, #[compact] value: T::Balance, memo: Memo) -> DispatchResult {
             let transactor = ensure_signed(origin)?;
             debug!("[transfer]|from:{:?}|to:{:?}|id:{:}|value:{:?}|memo:{}", transactor, dest, id, value, memo);
-            memo.check_validity().map_err(|_| Error::<T>::InvalidMemoLen)?;
+            memo.check_validity()?;
 
             Self::can_transfer(&id)?;
             let _ = Self::move_free_balance(&id, &transactor, &dest, value).map_err::<Error::<T>, _>(Into::into)?;
@@ -212,7 +212,7 @@ decl_module! {
         pub fn force_transfer(origin, transactor: T::AccountId, dest: T::AccountId, #[compact] id: AssetId, #[compact] value: T::Balance, memo: Memo) -> DispatchResult {
             ensure_root(origin)?;
             debug!("[force_transfer]|from:{:?}|to:{:?}|id:{:}|value:{:?}|memo:{}", transactor, dest, id, value, memo);
-            memo.check_validity().map_err(|_| Error::<T>::InvalidMemoLen)?;
+            memo.check_validity()?;
 
             Self::can_transfer(&id)?;
             let _ = Self::move_free_balance(&id, &transactor, &dest, value).map_err::<Error::<T>, _>(Into::into)?;

--- a/xrml/assets/src/lib.rs
+++ b/xrml/assets/src/lib.rs
@@ -34,9 +34,8 @@ pub use self::traits::{ChainT, OnAssetChanged, OnAssetRegisterOrRevoke, TokenJac
 use self::trigger::AssetTriggerEventAfter;
 
 pub use self::types::{
-    is_valid_desc, is_valid_memo, is_valid_token, Asset, AssetErr, AssetRestriction,
-    AssetRestrictions, AssetType, Chain, NegativeImbalance, PositiveImbalance, SignedBalance,
-    SignedImbalanceT,
+    is_valid_desc, is_valid_token, Asset, AssetErr, AssetRestriction, AssetRestrictions, AssetType,
+    Chain, NegativeImbalance, PositiveImbalance, SignedBalance, SignedImbalanceT,
 };
 
 pub struct SimpleAccountIdDeterminator<T: Trait>(::sp_std::marker::PhantomData<T>);
@@ -200,8 +199,8 @@ decl_module! {
         #[weight = 0]
         pub fn transfer(origin, dest: T::AccountId, #[compact] id: AssetId, #[compact] value: T::Balance, memo: Memo) -> DispatchResult {
             let transactor = ensure_signed(origin)?;
-            debug!("[transfer]|from:{:?}|to:{:?}|id:{:}|value:{:?}|memo:{:?}", transactor, dest, id, value, str!(memo));
-            is_valid_memo::<T>(&memo)?;
+            debug!("[transfer]|from:{:?}|to:{:?}|id:{:}|value:{:?}|memo:{}", transactor, dest, id, value, memo);
+            memo.check_validity().map_err(|_| Error::<T>::InvalidMemoLen)?;
 
             Self::can_transfer(&id)?;
             let _ = Self::move_free_balance(&id, &transactor, &dest, value).map_err::<Error::<T>, _>(Into::into)?;
@@ -212,8 +211,8 @@ decl_module! {
         #[weight = 0]
         pub fn force_transfer(origin, transactor: T::AccountId, dest: T::AccountId, #[compact] id: AssetId, #[compact] value: T::Balance, memo: Memo) -> DispatchResult {
             ensure_root(origin)?;
-            debug!("[force_transfer]|from:{:?}|to:{:?}|id:{:}|value:{:?}|memo:{:?}", transactor, dest, id, value, str!(memo));
-            is_valid_memo::<T>(&memo)?;
+            debug!("[force_transfer]|from:{:?}|to:{:?}|id:{:}|value:{:?}|memo:{}", transactor, dest, id, value, memo);
+            memo.check_validity().map_err(|_| Error::<T>::InvalidMemoLen)?;
 
             Self::can_transfer(&id)?;
             let _ = Self::move_free_balance(&id, &transactor, &dest, value).map_err::<Error::<T>, _>(Into::into)?;

--- a/xrml/assets/src/types.rs
+++ b/xrml/assets/src/types.rs
@@ -292,14 +292,6 @@ pub fn is_valid_desc<T: Trait>(desc: &[u8]) -> DispatchResult {
     Ok(())
 }
 
-/// A valid memo should have a legal length and be xss proof.
-pub fn is_valid_memo<T: Trait>(memo: &Memo) -> DispatchResult {
-    if memo.len() as u32 > Module::<T>::memo_len() {
-        Err(Error::<T>::InvalidMemoLen)?;
-    }
-    xrml_support::xss_check(memo)
-}
-
 mod imbalances {
     use frame_support::{traits::TryDrop, StorageMap};
     use sp_std::mem;

--- a/xrml/bridge/bitcoin/Cargo.toml
+++ b/xrml/bridge/bitcoin/Cargo.toml
@@ -7,17 +7,21 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", features = ["derive"], default-features = false }
-# substrate
+
+# Substrate primitives
 sp-std = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 sp-core = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
-# substrate runtime module
+
+# Substrate pallets
 frame-support = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 frame-system = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
-# chainx
+
+# ChainX primitives
 chainx-primitives = { path = "../../../primitives", default-features = false }
-# xrml
+
+# ChainX pallets
 xrml-protocol = { path = "../../protocol", default-features = false }
 xrml-support = { path = "../../support", default-features = false }
 xrml-assets = { path = "../../assets", default-features = false }

--- a/xrml/contracts/Cargo.toml
+++ b/xrml/contracts/Cargo.toml
@@ -18,20 +18,25 @@ codec = { package = "parity-scale-codec", version = "1.3.0", default-features = 
 parity-wasm = { version = "0.41.0", default-features = false }
 wasmi-validation = { version = "0.3.0", default-features = false }
 
+# Substrate primitives
 sp-core = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 sp-io = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 sp-sandbox = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 
+# Substrate pallets
 frame-support = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 frame-system = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 
+# ChainX primitives
 chainx-primitives = { path = "../../primitives", default-features = false }
+xrml-contracts-primitives = { path = "./common", default-features = false }
+
+# ChainX pallets
 xrml-support = { path = "../support", default-features = false }
 xrml-assets = { path = "../assets", default-features = false }
 xrml-transaction-payment = { path = "../transaction-payment", default-features = false }
-xrml-contracts-primitives = { path = "./common", default-features = false }
 
 [dev-dependencies]
 wabt = "0.9.2"

--- a/xrml/protocol/Cargo.toml
+++ b/xrml/protocol/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["ChainX community <http://www.chainx.org>"]
 edition = "2018"
 
 [dependencies]
+# ChainX primitives
 chainx-primitives = { path = "../../primitives", default-features = false }
 
 [features]

--- a/xrml/support/Cargo.toml
+++ b/xrml/support/Cargo.toml
@@ -7,8 +7,10 @@ edition = "2018"
 [dependencies]
 rustc-hex = { version = "2.0", optional = true }
 
+# Substrate primitives
 sp-std = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 
+# Substrate pallets
 frame-support = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 
 [features]

--- a/xrml/transaction-payment/Cargo.toml
+++ b/xrml/transaction-payment/Cargo.toml
@@ -15,12 +15,15 @@ targets = ["x86_64-unknown-linux-gnu"]
 smallvec = "1.4.0"
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
 
+# Substrate primitives
 sp-std = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 
+# Substrate pallets
 frame-support = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 frame-system = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc3", default-features = false }
 
+# ChainX pallets
 xrml-transaction-payment-rpc-runtime-api = { path = "./rpc/runtime-api", default-features = false }
 xrml-assets = { path = "../assets", default-features = false }
 


### PR DESCRIPTION
- Previously, we merely use a type alias for transaction `Memo`, i.e., `Vec<u8>`, now use a tuple struct and still apply the xss and size check.
- Remove unused type aliases in ChainX 2.0, e.g., `Name`, `URL`.