### PR TITLE
Make AssetChanged trait clearer sematically

### DIFF
--- a/xpallets/assets/src/lib.rs
+++ b/xpallets/assets/src/lib.rs
@@ -30,7 +30,7 @@ use frame_system::{self as system, ensure_root, ensure_signed};
 use chainx_primitives::{AssetId, Desc, Memo, Token};
 use xpallet_support::{debug, ensure_with_errorlog, info};
 
-use self::trigger::AssetTriggerEventAfter;
+use self::trigger::AssetChangedTrigger;
 
 pub use self::traits::{ChainT, OnAssetChanged, OnAssetRegisterOrRevoke, TokenJackpotAccountIdFor};
 pub use self::types::{
@@ -601,7 +601,7 @@ impl<T: Trait> Module<T> {
         // check
         let new = current.checked_add(&value).ok_or(Error::<T>::Overflow)?;
 
-        AssetTriggerEventAfter::<T>::on_issue_pre(id, who);
+        AssetChangedTrigger::<T>::on_issue_pre(id, who);
 
         // set to storage
         let imbalance = Self::make_type_balance_be(who, id, type_, new);
@@ -612,7 +612,7 @@ impl<T: Trait> Module<T> {
             PositiveImbalance::<T>::new(Zero::zero(), *id, type_)
         };
 
-        AssetTriggerEventAfter::<T>::on_issue_post(id, who, value)?;
+        AssetChangedTrigger::<T>::on_issue_post(id, who, value)?;
         Ok(positive)
     }
 
@@ -631,7 +631,7 @@ impl<T: Trait> Module<T> {
             .checked_sub(&value)
             .ok_or(Error::<T>::InsufficientBalance)?;
 
-        AssetTriggerEventAfter::<T>::on_destroy_pre(id, who);
+        AssetChangedTrigger::<T>::on_destroy_pre(id, who);
 
         let imbalance = Self::make_type_balance_be(who, id, type_, new);
         let negative = if let SignedImbalance::Negative(n) = imbalance {
@@ -641,7 +641,7 @@ impl<T: Trait> Module<T> {
             NegativeImbalance::<T>::new(Zero::zero(), *id, type_)
         };
 
-        AssetTriggerEventAfter::<T>::on_destroy_post(id, who, value)?;
+        AssetChangedTrigger::<T>::on_destroy_post(id, who, value)?;
         Ok(negative)
     }
 
@@ -683,8 +683,8 @@ impl<T: Trait> Module<T> {
             // same account, same type, return directly
             // same account also do trigger
             if do_trigger {
-                AssetTriggerEventAfter::<T>::on_move_pre(id, from, from_type, to, to_type, value);
-                AssetTriggerEventAfter::<T>::on_move_post(id, from, from_type, to, to_type, value)?;
+                AssetChangedTrigger::<T>::on_move_pre(id, from, from_type, to, to_type, value);
+                AssetChangedTrigger::<T>::on_move_post(id, from, from_type, to, to_type, value)?;
             }
             return Ok((
                 SignedImbalance::Positive(PositiveImbalance::<T>::zero()),
@@ -699,14 +699,14 @@ impl<T: Trait> Module<T> {
         }
 
         if do_trigger {
-            AssetTriggerEventAfter::<T>::on_move_pre(id, from, from_type, to, to_type, value);
+            AssetChangedTrigger::<T>::on_move_pre(id, from, from_type, to, to_type, value);
         }
 
         let from_imbalance = Self::make_type_balance_be(from, id, from_type, new_from_balance);
         let to_imbalance = Self::make_type_balance_be(to, id, to_type, new_to_balance);
 
         if do_trigger {
-            AssetTriggerEventAfter::<T>::on_move_post(id, from, from_type, to, to_type, value)?;
+            AssetChangedTrigger::<T>::on_move_post(id, from, from_type, to, to_type, value)?;
         }
         Ok((from_imbalance, to_imbalance))
     }
@@ -733,7 +733,7 @@ impl<T: Trait> Module<T> {
 
             let _imbalance = Self::make_type_balance_be(who, id, type_, val);
 
-            AssetTriggerEventAfter::<T>::on_set_balance(id, who, type_, val)?;
+            AssetChangedTrigger::<T>::on_set_balance(id, who, type_, val)?;
         }
         Ok(())
     }

--- a/xpallets/assets/src/lib.rs
+++ b/xpallets/assets/src/lib.rs
@@ -601,7 +601,7 @@ impl<T: Trait> Module<T> {
         // check
         let new = current.checked_add(&value).ok_or(Error::<T>::Overflow)?;
 
-        AssetTriggerEventAfter::<T>::on_issue_before(id, who);
+        AssetTriggerEventAfter::<T>::on_issue_pre(id, who);
 
         // set to storage
         let imbalance = Self::make_type_balance_be(who, id, type_, new);
@@ -612,7 +612,7 @@ impl<T: Trait> Module<T> {
             PositiveImbalance::<T>::new(Zero::zero(), *id, type_)
         };
 
-        AssetTriggerEventAfter::<T>::on_issue(id, who, value)?;
+        AssetTriggerEventAfter::<T>::on_issue_post(id, who, value)?;
         Ok(positive)
     }
 
@@ -631,7 +631,7 @@ impl<T: Trait> Module<T> {
             .checked_sub(&value)
             .ok_or(Error::<T>::InsufficientBalance)?;
 
-        AssetTriggerEventAfter::<T>::on_destroy_before(id, who);
+        AssetTriggerEventAfter::<T>::on_destroy_pre(id, who);
 
         let imbalance = Self::make_type_balance_be(who, id, type_, new);
         let negative = if let SignedImbalance::Negative(n) = imbalance {
@@ -641,7 +641,7 @@ impl<T: Trait> Module<T> {
             NegativeImbalance::<T>::new(Zero::zero(), *id, type_)
         };
 
-        AssetTriggerEventAfter::<T>::on_destroy(id, who, value)?;
+        AssetTriggerEventAfter::<T>::on_destroy_post(id, who, value)?;
         Ok(negative)
     }
 
@@ -683,10 +683,8 @@ impl<T: Trait> Module<T> {
             // same account, same type, return directly
             // same account also do trigger
             if do_trigger {
-                AssetTriggerEventAfter::<T>::on_move_before(
-                    id, from, from_type, to, to_type, value,
-                );
-                AssetTriggerEventAfter::<T>::on_move(id, from, from_type, to, to_type, value)?;
+                AssetTriggerEventAfter::<T>::on_move_pre(id, from, from_type, to, to_type, value);
+                AssetTriggerEventAfter::<T>::on_move_post(id, from, from_type, to, to_type, value)?;
             }
             return Ok((
                 SignedImbalance::Positive(PositiveImbalance::<T>::zero()),
@@ -701,14 +699,14 @@ impl<T: Trait> Module<T> {
         }
 
         if do_trigger {
-            AssetTriggerEventAfter::<T>::on_move_before(id, from, from_type, to, to_type, value);
+            AssetTriggerEventAfter::<T>::on_move_pre(id, from, from_type, to, to_type, value);
         }
 
         let from_imbalance = Self::make_type_balance_be(from, id, from_type, new_from_balance);
         let to_imbalance = Self::make_type_balance_be(to, id, to_type, new_to_balance);
 
         if do_trigger {
-            AssetTriggerEventAfter::<T>::on_move(id, from, from_type, to, to_type, value)?;
+            AssetTriggerEventAfter::<T>::on_move_post(id, from, from_type, to, to_type, value)?;
         }
         Ok((from_imbalance, to_imbalance))
     }

--- a/xpallets/assets/src/traits.rs
+++ b/xpallets/assets/src/traits.rs
@@ -23,27 +23,47 @@ pub trait ChainT {
     }
 }
 
+/// Hooks for performing operations when the asset changes.
 pub trait OnAssetChanged<AccountId, Balance> {
-    fn on_move_before(
-        id: &AssetId,
-        from: &AccountId,
-        from_type: AssetType,
-        to: &AccountId,
-        to_type: AssetType,
-        value: Balance,
-    );
-    fn on_move(
-        id: &AssetId,
-        from: &AccountId,
-        from_type: AssetType,
-        to: &AccountId,
-        to_type: AssetType,
-        value: Balance,
-    ) -> result::Result<(), AssetErr>;
-    fn on_issue_before(id: &AssetId, who: &AccountId);
-    fn on_issue(id: &AssetId, who: &AccountId, value: Balance) -> DispatchResult;
-    fn on_destroy_before(id: &AssetId, who: &AccountId);
-    fn on_destroy(id: &AssetId, who: &AccountId, value: Balance) -> DispatchResult;
+    /// Triggered before moving the assets.
+    fn on_move_pre(
+        _id: &AssetId,
+        _from: &AccountId,
+        _from_type: AssetType,
+        _to: &AccountId,
+        _to_type: AssetType,
+        _value: Balance,
+    ) {
+    }
+
+    /// Triggered after moving the assets.
+    fn on_move_post(
+        _id: &AssetId,
+        _from: &AccountId,
+        _from_type: AssetType,
+        _to: &AccountId,
+        _to_type: AssetType,
+        _value: Balance,
+    ) -> result::Result<(), AssetErr> {
+        Ok(())
+    }
+
+    /// Triggered before issuing the fresh assets.
+    fn on_issue_pre(_id: &AssetId, _who: &AccountId) {}
+
+    /// Triggered after issuing the fresh assets.
+    fn on_issue_post(_id: &AssetId, _who: &AccountId, _value: Balance) -> DispatchResult {
+        Ok(())
+    }
+
+    /// Triggered before destorying the assets.
+    fn on_destroy_pre(_id: &AssetId, _who: &AccountId) {}
+
+    /// Triggered after destorying the assets.
+    fn on_destroy_post(_id: &AssetId, _who: &AccountId, _value: Balance) -> DispatchResult {
+        Ok(())
+    }
+
     fn on_set_balance(
         _id: &AssetId,
         _who: &AccountId,
@@ -55,6 +75,10 @@ pub trait OnAssetChanged<AccountId, Balance> {
 }
 
 pub trait OnAssetRegisterOrRevoke {
-    fn on_register(_: &AssetId, _: bool) -> DispatchResult;
-    fn on_revoke(_: &AssetId) -> DispatchResult;
+    fn on_register(_: &AssetId, _: bool) -> DispatchResult {
+        Ok(())
+    }
+    fn on_revoke(_: &AssetId) -> DispatchResult {
+        Ok(())
+    }
 }

--- a/xpallets/assets/src/traits.rs
+++ b/xpallets/assets/src/traits.rs
@@ -23,8 +23,16 @@ pub trait ChainT {
     }
 }
 
-/// Hooks for performing operations when the asset changes.
+/// Hooks for doing stuff when the assets are minted/moved/destroied..
 pub trait OnAssetChanged<AccountId, Balance> {
+    /// Triggered before issuing the fresh assets.
+    fn on_issue_pre(_id: &AssetId, _who: &AccountId) {}
+
+    /// Triggered after issuing the fresh assets.
+    fn on_issue_post(_id: &AssetId, _who: &AccountId, _value: Balance) -> DispatchResult {
+        Ok(())
+    }
+
     /// Triggered before moving the assets.
     fn on_move_pre(
         _id: &AssetId,
@@ -48,18 +56,10 @@ pub trait OnAssetChanged<AccountId, Balance> {
         Ok(())
     }
 
-    /// Triggered before issuing the fresh assets.
-    fn on_issue_pre(_id: &AssetId, _who: &AccountId) {}
-
-    /// Triggered after issuing the fresh assets.
-    fn on_issue_post(_id: &AssetId, _who: &AccountId, _value: Balance) -> DispatchResult {
-        Ok(())
-    }
-
-    /// Triggered before destorying the assets.
+    /// Triggered before destroying the assets.
     fn on_destroy_pre(_id: &AssetId, _who: &AccountId) {}
 
-    /// Triggered after destorying the assets.
+    /// Triggered after the assets has been destroied.
     fn on_destroy_post(_id: &AssetId, _who: &AccountId, _value: Balance) -> DispatchResult {
         Ok(())
     }

--- a/xpallets/assets/src/traits.rs
+++ b/xpallets/assets/src/traits.rs
@@ -23,7 +23,7 @@ pub trait ChainT {
     }
 }
 
-/// Hooks for doing stuff when the assets are minted/moved/destroied..
+/// Hooks for doing stuff when the assets are minted/moved/destroyed.
 pub trait OnAssetChanged<AccountId, Balance> {
     /// Triggered before issuing the fresh assets.
     fn on_issue_pre(_id: &AssetId, _who: &AccountId) {}
@@ -59,7 +59,7 @@ pub trait OnAssetChanged<AccountId, Balance> {
     /// Triggered before destroying the assets.
     fn on_destroy_pre(_id: &AssetId, _who: &AccountId) {}
 
-    /// Triggered after the assets has been destroied.
+    /// Triggered after the assets has been destroyed.
     fn on_destroy_post(_id: &AssetId, _who: &AccountId, _value: Balance) -> DispatchResult {
         Ok(())
     }

--- a/xpallets/assets/src/trigger.rs
+++ b/xpallets/assets/src/trigger.rs
@@ -35,9 +35,9 @@ impl<A: OnAssetRegisterOrRevoke, B: OnAssetRegisterOrRevoke> OnAssetRegisterOrRe
     }
 }
 
-pub struct AssetTriggerEventAfter<T: Trait>(::sp_std::marker::PhantomData<T>);
+pub struct AssetChangedTrigger<T: Trait>(::sp_std::marker::PhantomData<T>);
 
-impl<T: Trait> AssetTriggerEventAfter<T> {
+impl<T: Trait> AssetChangedTrigger<T> {
     pub fn on_move_pre(
         id: &AssetId,
         from: &T::AccountId,


### PR DESCRIPTION
For example, `on_issue` actually happens after the `issue` operation, using `on_issue_post` makes the timing more explicitly.