### PR TITLE
Add a mining common trait: RewardPotAccountFor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7083,6 +7083,7 @@ dependencies = [
  "env_logger",
  "frame-support",
  "frame-system",
+ "pallet-session",
  "parity-scale-codec",
  "serde",
  "sp-arithmetic",

--- a/primitives/mining/common/src/lib.rs
+++ b/primitives/mining/common/src/lib.rs
@@ -27,7 +27,7 @@
 //! staked_balance(Balance) * time(BlockNumber) = vote_weight
 //! ```
 //!
-//! All the nominators split the reward of the validator's jackpot according to the proportion of vote weight.
+//! All the nominators split the reward of the validator's reward pot according to the proportion of vote weight.
 //!
 //! For Asset Mining:
 //!
@@ -35,7 +35,7 @@
 //! ext_asset_balance(Balance) * time(BlockNumber) = ext_mining_weight
 //! ```
 //!
-//! All asset miners split the reward of asset's jackpot according to the proportion of asset mining weight.
+//! All asset miners split the reward of asset's reward pot according to the proportion of asset mining weight.
 //!
 
 use sp_arithmetic::traits::{BaseArithmetic, SaturatedConversion};
@@ -196,18 +196,15 @@ pub trait Claim<AccountId> {
 ///
 /// The reward of all individual miners will be staged in the reward pot, the individual
 /// reward can be claimed manually at any time.
-pub trait RewardPotAccountFor<AccountId> {
+pub trait RewardPotAccountFor<AccountId, MiningEntity> {
     /// Entity of the mining participant.
     ///
     /// The entity can be a Staking Validator or a Mining Asset.
-    type MiningEntity;
-
-    fn reward_pot_account_for(_entity: &Self::MiningEntity) -> AccountId;
+    fn reward_pot_account_for(_entity: &MiningEntity) -> AccountId;
 }
 
-impl<AccountId: Default> RewardPotAccountFor<AccountId> for () {
-    type MiningEntity = ();
-    fn reward_pot_account_for(_entity: &Self::MiningEntity) -> AccountId {
+impl<AccountId: Default, MiningEntity> RewardPotAccountFor<AccountId, MiningEntity> for () {
+    fn reward_pot_account_for(_entity: &MiningEntity) -> AccountId {
         Default::default()
     }
 }

--- a/primitives/mining/common/src/lib.rs
+++ b/primitives/mining/common/src/lib.rs
@@ -191,3 +191,23 @@ pub trait Claim<AccountId> {
 
     fn claim(claimer: &AccountId, claimee: &Self::Claimee) -> Result<(), Self::Error>;
 }
+
+/// A function that generates an `AccountId` for the reward pot of a mining entity.
+///
+/// The reward of all individual miners will be staged in the reward pot, the individual
+/// reward can be claimed manually at any time.
+pub trait RewardPotAccountFor<AccountId> {
+    /// Entity of the mining participant.
+    ///
+    /// The entity can be a Staking Validator or a Mining Asset.
+    type MiningEntity;
+
+    fn reward_pot_account_for(_entity: &Self::MiningEntity) -> AccountId;
+}
+
+impl<AccountId: Default> RewardPotAccountFor<AccountId> for () {
+    type MiningEntity = ();
+    fn reward_pot_account_for(_entity: &Self::MiningEntity) -> AccountId {
+        Default::default()
+    }
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -276,18 +276,11 @@ impl xpallet_dex_spot::Trait for Runtime {
     type Price = Balance;
 }
 
-pub struct Tmp;
-impl xpallet_assets::TokenJackpotAccountIdFor<AccountId, BlockNumber> for Tmp {
-    fn accountid_for(_id: &AssetId) -> AccountId {
-        unimplemented!()
-    }
-}
 impl xpallet_assets::Trait for Runtime {
     type Balance = Balance;
     type Event = Event;
     type OnAssetChanged = XMiningAsset;
     type OnAssetRegisterOrRevoke = XMiningAsset;
-    type DetermineTokenJackpotAccountId = Tmp;
 }
 
 impl xpallet_bridge_bitcoin::Trait for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -304,10 +304,14 @@ impl xpallet_mining_staking::Trait for Runtime {
     type Event = Event;
     type CollectAssetMiningInfo = ();
     type OnMinting = ();
+    type DetermineRewardPotAccount =
+        xpallet_mining_staking::SimpleValidatorRewardPotAccountDeterminer<Runtime>;
 }
 
 impl xpallet_mining_asset::Trait for Runtime {
     type Event = Event;
+    type DetermineRewardPotAccount =
+        xpallet_mining_asset::SimpleAssetRewardPotAccountDeterminer<Runtime>;
 }
 
 parameter_types! {

--- a/xpallets/assets/src/lib.rs
+++ b/xpallets/assets/src/lib.rs
@@ -39,32 +39,6 @@ pub use self::types::{
     TotalAssetInfo,
 };
 
-pub struct SimpleAccountIdDeterminator<T: Trait>(::sp_std::marker::PhantomData<T>);
-
-impl<AccountId: Default, BlockNumber> TokenJackpotAccountIdFor<AccountId, BlockNumber> for () {
-    fn accountid_for(_: &AssetId) -> AccountId {
-        AccountId::default()
-    }
-}
-
-impl<T: Trait> TokenJackpotAccountIdFor<T::AccountId, T::BlockNumber>
-    for SimpleAccountIdDeterminator<T>
-where
-    T::AccountId: UncheckedFrom<T::Hash>,
-    T::BlockNumber: codec::Codec,
-{
-    fn accountid_for(id: &AssetId) -> T::AccountId {
-        let id_hash = T::Hashing::hash(&id.to_le_bytes()[..]);
-        let registered_time = Module::<T>::asset_registered_block(id);
-        let block_num_hash = T::Hashing::hash(registered_time.encode().as_ref());
-
-        let mut buf = Vec::new();
-        buf.extend_from_slice(id_hash.as_ref());
-        buf.extend_from_slice(block_num_hash.as_ref());
-        UncheckedFrom::unchecked_from(T::Hashing::hash(&buf[..]))
-    }
-}
-
 pub trait Trait: system::Trait {
     type Balance: Parameter
         + Member
@@ -80,12 +54,6 @@ pub trait Trait: system::Trait {
     type OnAssetChanged: OnAssetChanged<Self::AccountId, Self::Balance>;
 
     type OnAssetRegisterOrRevoke: OnAssetRegisterOrRevoke;
-
-    /// Generate virtual AccountId for each (psedu) token
-    type DetermineTokenJackpotAccountId: TokenJackpotAccountIdFor<
-        Self::AccountId,
-        Self::BlockNumber,
-    >;
 }
 
 decl_error! {

--- a/xpallets/assets/src/lib.rs
+++ b/xpallets/assets/src/lib.rs
@@ -32,7 +32,7 @@ use xpallet_support::{debug, ensure_with_errorlog, info};
 
 use self::trigger::AssetChangedTrigger;
 
-pub use self::traits::{ChainT, OnAssetChanged, OnAssetRegisterOrRevoke, TokenJackpotAccountIdFor};
+pub use self::traits::{ChainT, OnAssetChanged, OnAssetRegisterOrRevoke};
 pub use self::types::{
     is_valid_desc, is_valid_token, AssetErr, AssetInfo, AssetRestriction, AssetRestrictions,
     AssetType, Chain, NegativeImbalance, PositiveImbalance, SignedBalance, SignedImbalanceT,

--- a/xpallets/assets/src/traits.rs
+++ b/xpallets/assets/src/traits.rs
@@ -6,10 +6,6 @@ use chainx_primitives::AssetId;
 
 use crate::types::{AssetErr, AssetType, Chain};
 
-pub trait TokenJackpotAccountIdFor<AccountId: Sized, BlockNumber> {
-    fn accountid_for(id: &AssetId) -> AccountId;
-}
-
 pub trait ChainT {
     /// ASSET should be the native Asset for this chain.
     /// e.g.

--- a/xpallets/bridge/bitcoin/src/tests/mock.rs
+++ b/xpallets/bridge/bitcoin/src/tests/mock.rs
@@ -95,7 +95,6 @@ impl xpallet_assets::Trait for Test {
     type OnNewAccount = ();
     type OnAssetChanged = ();
     type OnAssetRegisterOrRevoke = ();
-    type DetermineTokenJackpotAccountId = ();
     type Event = ();
 }
 

--- a/xpallets/dex/spot/src/mock.rs
+++ b/xpallets/dex/spot/src/mock.rs
@@ -76,7 +76,6 @@ impl xpallet_assets::Trait for Test {
     type Event = ();
     type OnAssetChanged = ();
     type OnAssetRegisterOrRevoke = XSpot;
-    type DetermineTokenJackpotAccountId = ();
 }
 
 thread_local! {

--- a/xpallets/mining/asset/Cargo.toml
+++ b/xpallets/mining/asset/Cargo.toml
@@ -10,6 +10,7 @@ serde = { version = "1.0.101", optional = true }
 
 # Substrate primitives
 sp-std = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc4", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc4", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc4", default-features = false }
 sp-arithmetic = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc4", default-features = false }
 
@@ -40,6 +41,7 @@ std = [
     "serde",
 
     "sp-std/std",
+    "sp-core/std",
     "sp-runtime/std",
     "sp-arithmetic/std",
 

--- a/xpallets/mining/asset/src/lib.rs
+++ b/xpallets/mining/asset/src/lib.rs
@@ -27,14 +27,20 @@ use sp_runtime::traits::{
 use sp_std::prelude::*;
 use types::*;
 use xp_mining_common::{
-    Claim, ComputeMiningWeight, MiningWeight, WeightType, ZeroMiningWeightError,
+    Claim, ComputeMiningWeight, MiningWeight, RewardPotAccountFor, WeightType,
+    ZeroMiningWeightError,
 };
 use xpallet_assets::{AssetErr, AssetType};
 use xpallet_support::debug;
 
+pub use impls::SimpleAssetRewardPotAccountDeterminer;
+
 pub trait Trait: frame_system::Trait + xpallet_assets::Trait {
     /// The overarching event type.
     type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
+
+    ///
+    type DetermineRewardPotAccount: RewardPotAccountFor<Self::AccountId, AssetId>;
 }
 
 decl_storage! {
@@ -213,12 +219,12 @@ impl<T: Trait> Module<T> {
     fn compute_dividend(
         source_weight: WeightType,
         target_weight: WeightType,
-        claimee_jackpot: &T::AccountId,
+        claimee_reward_pot: &T::AccountId,
     ) -> T::Balance {
         todo!()
     }
 
-    fn asset_jackpot_of(asset_id: &AssetId) -> T::AccountId {
+    fn asset_reward_pot_of(asset_id: &AssetId) -> T::AccountId {
         todo!()
     }
 }

--- a/xpallets/mining/asset/src/mock.rs
+++ b/xpallets/mining/asset/src/mock.rs
@@ -73,7 +73,6 @@ impl xpallet_assets::Trait for Test {
     type Event = ();
     type OnAssetChanged = XMiningAsset;
     type OnAssetRegisterOrRevoke = XMiningAsset;
-    type DetermineTokenJackpotAccountId = ();
 }
 
 impl xpallet_mining_staking::Trait for Test {

--- a/xpallets/mining/asset/src/mock.rs
+++ b/xpallets/mining/asset/src/mock.rs
@@ -66,6 +66,7 @@ impl system::Trait for Test {
 
 impl Trait for Test {
     type Event = ();
+    type DetermineRewardPotAccount = ();
 }
 
 impl xpallet_assets::Trait for Test {
@@ -79,6 +80,7 @@ impl xpallet_mining_staking::Trait for Test {
     type Event = ();
     type OnMinting = ();
     type CollectAssetMiningInfo = ();
+    type DetermineRewardPotAccount = ();
 }
 
 // This function basically just builds a genesis storage key/value store according to

--- a/xpallets/mining/staking/Cargo.toml
+++ b/xpallets/mining/staking/Cargo.toml
@@ -10,12 +10,14 @@ serde = { version = "1.0.101", optional = true }
 
 # Substrate primitives
 sp-std = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc4", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc4", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc4", default-features = false }
 sp-arithmetic = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc4", default-features = false }
 
 # Substrate pallets
 frame-support = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc4", default-features = false }
 frame-system = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc4", default-features = false }
+pallet-session = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc4", default-features = false }
 
 # ChainX primitives
 chainx-primitives = { path = "../../../primitives", default-features = false }
@@ -39,11 +41,13 @@ std = [
     "serde",
 
     "sp-std/std",
+    "sp-core/std",
     "sp-runtime/std",
     "sp-arithmetic/std",
 
     "frame-support/std",
     "frame-system/std",
+    "pallet-session/std",
 
     "chainx-primitives/std",
     "xp-mining-common/std",

--- a/xpallets/mining/staking/src/impls.rs
+++ b/xpallets/mining/staking/src/impls.rs
@@ -244,7 +244,6 @@ impl<T: Trait> xp_mining_common::RewardPotAccountFor<T::AccountId, T::AccountId>
 where
     T::AccountId: UncheckedFrom<T::Hash> + AsRef<[u8]>,
 {
-    // type MiningEntity = T::AccountId;
     fn reward_pot_account_for(validator: &T::AccountId) -> T::AccountId {
         let validator_hash = <T as frame_system::Trait>::Hashing::hash(validator.as_ref());
         let registered_at: T::BlockNumber = Validators::<T>::get(validator).registered_at;

--- a/xpallets/mining/staking/src/impls.rs
+++ b/xpallets/mining/staking/src/impls.rs
@@ -1,8 +1,11 @@
 use super::*;
 use sp_arithmetic::traits::BaseArithmetic;
+use sp_core::crypto::UncheckedFrom;
+use sp_runtime::traits::Hash;
 use xp_mining_common::{
     generic_weight_factors, BaseMiningWeight, Claim, ComputeMiningWeight, WeightFactors, WeightType,
 };
+use xp_mining_staking::SessionIndex;
 
 impl<Balance, BlockNumber> BaseMiningWeight<Balance, BlockNumber>
     for ValidatorLedger<Balance, BlockNumber>
@@ -199,5 +202,48 @@ impl<T: Trait> Claim<T::AccountId> for Module<T> {
         Self::update_claimee_vote_weight_on_claim(claimee, new_target_weight, current_block);
 
         Ok(())
+    }
+}
+
+impl<T: Trait> Module<T> {
+    fn new_session(new_index: SessionIndex) -> Option<Vec<T::AccountId>> {
+        todo!()
+    }
+
+    fn start_session(start_index: SessionIndex) {
+        todo!()
+    }
+
+    fn end_session(end_index: SessionIndex) {
+        todo!()
+    }
+}
+
+/// In this implementation `new_session(session)` must be called before `end_session(session-1)`
+/// i.e. the new session must be planned before the ending of the previous session.
+///
+/// Once the first new_session is planned, all session must start and then end in order, though
+/// some session can lag in between the newest session planned and the latest session started.
+impl<T: Trait> pallet_session::SessionManager<T::AccountId> for Module<T> {
+    fn new_session(new_index: SessionIndex) -> Option<Vec<T::AccountId>> {
+        Self::new_session(new_index)
+    }
+    fn start_session(start_index: SessionIndex) {
+        Self::start_session(start_index)
+    }
+    fn end_session(end_index: SessionIndex) {
+        Self::end_session(end_index)
+    }
+}
+
+impl<T: Trait> xp_mining_common::RewardPotAccountFor<T::AccountId> for Module<T>
+where
+    T::AccountId: UncheckedFrom<T::Hash> + AsRef<[u8]>,
+{
+    type MiningEntity = T::AccountId;
+    fn reward_pot_account_for(validator: &Self::MiningEntity) -> T::AccountId {
+        UncheckedFrom::unchecked_from(<T as frame_system::Trait>::Hashing::hash(
+            validator.as_ref(),
+        ))
     }
 }

--- a/xpallets/mining/staking/src/lib.rs
+++ b/xpallets/mining/staking/src/lib.rs
@@ -28,10 +28,14 @@ use sp_runtime::traits::{
 };
 use sp_std::prelude::*;
 use types::*;
-use xp_mining_common::{Claim, ComputeMiningWeight, Delta, ZeroMiningWeightError};
+use xp_mining_common::{
+    Claim, ComputeMiningWeight, Delta, RewardPotAccountFor, ZeroMiningWeightError,
+};
 use xp_mining_staking::{CollectAssetMiningInfo, OnMinting, UnbondedIndex};
 use xpallet_assets::{AssetErr, AssetType};
 use xpallet_support::debug;
+
+pub use impls::SimpleValidatorRewardPotAccountDeterminer;
 
 /// Session reward of the first 210_000 sessions.
 const INITIAL_REWARD: u64 = 50;
@@ -59,6 +63,9 @@ pub trait Trait: frame_system::Trait + xpallet_assets::Trait {
 
     ///
     type OnMinting: OnMinting<AssetId, Self::Balance>;
+
+    ///
+    type DetermineRewardPotAccount: RewardPotAccountFor<Self::AccountId, Self::AccountId>;
 }
 
 decl_storage! {

--- a/xpallets/mining/staking/src/lib.rs
+++ b/xpallets/mining/staking/src/lib.rs
@@ -3,6 +3,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 mod impls;
+// mod reward;
 mod types;
 
 #[cfg(test)]
@@ -31,6 +32,14 @@ use xp_mining_common::{Claim, ComputeMiningWeight, Delta, ZeroMiningWeightError}
 use xp_mining_staking::{CollectAssetMiningInfo, OnMinting, UnbondedIndex};
 use xpallet_assets::{AssetErr, AssetType};
 use xpallet_support::debug;
+
+/// Session reward of the first 210_000 sessions.
+const INITIAL_REWARD: u64 = 50;
+/// Every 210_000 sessions, the session reward is cut in half.
+///
+/// ChainX follows the issuance rule of Bitcoin. The `Session` in ChainX
+/// is equivalent to `Block` in Bitcoin with regard to minting new coins.
+const SESSIONS_PER_ROUND: u32 = 210_000;
 
 const DEFAULT_MINIMUM_VALIDATOR_COUNT: u32 = 4;
 const DEFAULT_MAXIMUM_VALIDATOR_COUNT: u32 = 100;
@@ -88,6 +97,9 @@ decl_storage! {
         /// Maximum number of on-going unbonded chunk.
         pub MaximumUnbondedChunkSize get(fn maximum_unbonded_chunk_size) config():
             u32 = DEFAULT_MAXIMUM_UNBONDED_CHUNK_SIZE;
+
+        /// The beneficiary account of vesting schedule.
+        pub VestingAccount get(fn vesting_account) config(): T::AccountId;
 
         /// Maximum value of total_bonded/self_bonded.
         pub UpperBoundFactorOfAcceptableVotes get(fn upper_bound_factor) config():

--- a/xpallets/mining/staking/src/mock.rs
+++ b/xpallets/mining/staking/src/mock.rs
@@ -75,7 +75,6 @@ impl xpallet_assets::Trait for Test {
     type Event = ();
     type OnAssetChanged = ();
     type OnAssetRegisterOrRevoke = ();
-    type DetermineTokenJackpotAccountId = ();
 }
 
 // This function basically just builds a genesis storage key/value store according to

--- a/xpallets/mining/staking/src/mock.rs
+++ b/xpallets/mining/staking/src/mock.rs
@@ -68,6 +68,7 @@ impl Trait for Test {
     type Event = ();
     type OnMinting = ();
     type CollectAssetMiningInfo = ();
+    type DetermineRewardPotAccount = ();
 }
 
 impl xpallet_assets::Trait for Test {

--- a/xpallets/mining/staking/src/types.rs
+++ b/xpallets/mining/staking/src/types.rs
@@ -117,8 +117,8 @@ pub struct ValidatorInfo<AccountId: Default, Balance: Default, BlockNumber: Defa
     pub profile: ValidatorProfile<BlockNumber>,
     #[cfg_attr(feature = "std", serde(flatten))]
     pub ledger: ValidatorLedger<Balance, BlockNumber>,
-    pub jackpot_account: AccountId,
-    pub jackpot_balance: Balance,
+    pub status: ValidatorStatus,
     pub self_bonded: Balance,
-    pub status: bool,
+    pub reward_pot_account: AccountId,
+    pub reward_pot_balance: Balance,
 }

--- a/xpallets/protocol/src/lib.rs
+++ b/xpallets/protocol/src/lib.rs
@@ -35,15 +35,19 @@ pub mod assets_def {
     //      L_: use 0x90000000
     //      S_: use 0xa0000000
 
-    // notic index 0 strands for ChainX PCX, not Bitcoin(BTC)
+    /// notic index 0 strands for ChainX PCX, not Bitcoin(BTC)
     pub const PCX: AssetId = 0;
-    // notice index 1 stands for mainnet Bitcoin, not testnet Bitcoin asset
+    /// Bitcoin
+    ///
+    /// notice index 1 stands for mainnet Bitcoin, not testnet Bitcoin asset
     pub const X_BTC: AssetId = 1;
+    /// Reserved for legacy ChainX 1.0.
     pub const L_BTC: AssetId = 0x90000000 | X_BTC;
 
     pub const X_ETH: AssetId = 60;
 
     pub const X_DOT: AssetId = 354;
+    /// Reserved for legacy ChainX 1.0.
     pub const S_DOT: AssetId = 0xa0000000 | X_DOT;
 
     const EXTEND: AssetId = 0x01000000;

--- a/xpallets/protocol/src/lib.rs
+++ b/xpallets/protocol/src/lib.rs
@@ -57,13 +57,13 @@ mod assets_registration {
     ///
     /// Notice index 1 stands for mainnet Bitcoin, not testnet Bitcoin asset.
     pub const X_BTC: AssetId = 1;
-    /// Reserved since this symbol has been used in legacy ChainX 1.0.
+    /// Reserved since this symbol had been used in legacy ChainX 1.0.
     pub const L_BTC: AssetId = 0x90000000 | X_BTC;
     ///
     pub const X_ETH: AssetId = 60;
     ///
     pub const X_DOT: AssetId = 354;
-    /// Reserved since this symbol has been used in legacy ChainX 1.0.
+    /// Reserved since this symbol had been used in legacy ChainX 1.0.
     pub const S_DOT: AssetId = 0xa0000000 | X_DOT;
 
     const EXTEND: AssetId = 0x01000000;

--- a/xpallets/protocol/src/lib.rs
+++ b/xpallets/protocol/src/lib.rs
@@ -6,13 +6,27 @@ use serde::{Deserialize, Serialize};
 
 use chainx_primitives::AssetId;
 
-pub mod assets_def {
+pub use assets_registration::*;
+pub use network::*;
+
+/// assets
+pub const ASSET_SYMBOL_LEN: usize = 24;
+///
+pub const ASSET_NAME_LEN: usize = 48;
+///
+pub const ASSET_DESC_LEN: usize = 128;
+///
+pub const MEMO_BYTES_LEN: usize = 80;
+
+mod assets_registration {
     use super::*;
 
     // match to SLIP-0044 Registered coin types for BIP-0044
     // [Registered coin types](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
+    //
     // Particular, ChainX Native token PCX occupies Testnet index, which is not same in SLIP44 standard.
     // so that, ChainX AssetId protocol is:
+    //
     // 1. base token:
     //      base token stands for the real token for this Asset on ChainX, all have "X_" prefix, means
     //      cross chain (e.g. BTC is X_BTC, ETH is X_ETH), and ths base token AssetId is from SLIP44
@@ -20,10 +34,12 @@ pub mod assets_def {
     //      But inside, we agree on using Testnet index 1 to stand for **mainnet Bitcoin asset**,
     //      not testnet. And on the other hand, we use 0 to stand for ChainX native token "PCX",
     // and others is all match to SLIP44 "coin type" index.
+    //
     // 2. some token chich not in SLIP44 coin types:
     //      e.g. USDT not int SLIP44, thus we use `0x01000000 | id` to extend AssetId for containing
     //      there assets. The AssetId in this part is decided by ChainX.
     //      For example, we agree on pointing 0x01 as the USDT, thus USDT AssetId is `0x01000000|0x01`
+    //
     // 3. derived token on ChainX for the cross chain token.
     //      ChainX would derived some special token which just on ChainX and it is not real cross
     //      assets but also have some relationship to source chain assets. Thus we use some
@@ -35,35 +51,27 @@ pub mod assets_def {
     //      L_: use 0x90000000
     //      S_: use 0xa0000000
 
-    /// notic index 0 strands for ChainX PCX, not Bitcoin(BTC)
+    /// Native coin type of ChainX.
     pub const PCX: AssetId = 0;
-    /// Bitcoin
+    /// BTC asset in ChainX backed by the Mainnet Bitcoin.
     ///
-    /// notice index 1 stands for mainnet Bitcoin, not testnet Bitcoin asset
+    /// Notice index 1 stands for mainnet Bitcoin, not testnet Bitcoin asset.
     pub const X_BTC: AssetId = 1;
-    /// Reserved for legacy ChainX 1.0.
+    /// Reserved since this symbol has been used in legacy ChainX 1.0.
     pub const L_BTC: AssetId = 0x90000000 | X_BTC;
-
+    ///
     pub const X_ETH: AssetId = 60;
-
+    ///
     pub const X_DOT: AssetId = 354;
-    /// Reserved for legacy ChainX 1.0.
+    /// Reserved since this symbol has been used in legacy ChainX 1.0.
     pub const S_DOT: AssetId = 0xa0000000 | X_DOT;
 
     const EXTEND: AssetId = 0x01000000;
+    ///
     pub const USDT: AssetId = EXTEND | 0x01;
 }
 
-pub use assets_def::*;
-
-// assets
-pub const ASSET_SYMBOL_LEN: usize = 24;
-pub const ASSET_NAME_LEN: usize = 48;
-pub const ASSET_DESC_LEN: usize = 128;
-
-pub const MEMO_BYTES_LEN: usize = 80;
-
-pub mod network {
+mod network {
     use super::*;
     pub type AddrVersion = u8;
 
@@ -88,7 +96,7 @@ pub mod network {
             }
         }
     }
+
     pub const MAINNET_ADDR_VER: AddrVersion = 44;
     pub const TESTNET_ADDR_VER: AddrVersion = 45;
 }
-pub use network::*;


### PR DESCRIPTION
- The trait `RewardPotAccountFor` decouples the reward pot calculation from the assets module, for it's a mining specific concept upon the asset definition.
- Rename the previous `jackpot` to `reward_pot`, this term is also used in another blockchain project  [colonyNetwork](https://github.com/JoinColony/colonyNetwork), I guess this word might be easier for the new comers to understand.
- Add some docs in xpallet_protocol.