### PR TITLE
Add validator referral_id

### DIFF
--- a/cli/src/chain_spec.rs
+++ b/cli/src/chain_spec.rs
@@ -320,13 +320,11 @@ fn testnet_genesis(
     let mut assets_endowed = endowed.clone();
     assets_endowed.remove(&xpallet_protocol::PCX);
 
-    let validators = {
-        initial_authorities
-            .clone()
-            .into_iter()
-            .map(|((v, r), _, _, _, _)| (v, r, STAKING_LOCKED))
-            .collect::<Vec<_>>()
-    };
+    let validators = initial_authorities
+        .clone()
+        .into_iter()
+        .map(|((val, referral_id), _, _, _, _)| (val, referral_id, STAKING_LOCKED))
+        .collect::<Vec<_>>();
 
     GenesisConfig {
         frame_system: Some(SystemConfig {

--- a/cli/src/chain_spec.rs
+++ b/cli/src/chain_spec.rs
@@ -7,7 +7,7 @@ use chainx_runtime::{
     constants, trustees, AssetInfo, AssetRestriction, AssetRestrictions, BtcParams, BtcTxVerifier,
     Chain, ContractsSchedule, NetworkType, TrusteeInfoConfig,
 };
-use chainx_runtime::{AccountId, AssetId, Balance, Runtime, Signature, WASM_BINARY};
+use chainx_runtime::{AccountId, AssetId, Balance, ReferralId, Runtime, Signature, WASM_BINARY};
 use chainx_runtime::{
     AuraConfig, BalancesConfig, CouncilConfig, DemocracyConfig, ElectionsConfig, GenesisConfig,
     GrandpaConfig, ImOnlineConfig, SessionConfig, SessionKeys, SocietyConfig, SudoConfig,
@@ -45,12 +45,21 @@ where
     AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
 }
 
+type AuthorityKeysTuple = (
+    (AccountId, ReferralId), // (Staking ValidatorId, ReferralId)
+    AccountId,               // (SessionKey)
+    AuraId,
+    GrandpaId,
+    ImOnlineId,
+);
+
 /// Helper function to generate an authority key for Aura
-pub fn authority_keys_from_seed(
-    seed: &str,
-) -> (AccountId, AccountId, AuraId, GrandpaId, ImOnlineId) {
+pub fn authority_keys_from_seed(seed: &str) -> AuthorityKeysTuple {
     (
-        get_account_id_from_seed::<sr25519::Public>(seed),
+        (
+            get_account_id_from_seed::<sr25519::Public>(seed),
+            seed.as_bytes().to_vec(),
+        ),
         get_account_id_from_seed::<sr25519::Public>(&format!("{}//blockauthor", seed)),
         get_from_seed::<AuraId>(seed),
         get_from_seed::<GrandpaId>(seed),
@@ -78,6 +87,17 @@ macro_rules! endowed_gen {
     }
 }
 
+/// Helper function to generate the network properties.
+fn as_properties(network: NetworkType) -> Properties {
+    json!({
+        "ss58Format": network.addr_version(),
+        "network": network,
+    })
+    .as_object()
+    .expect("network properties generation can not fail; qed")
+    .to_owned()
+}
+
 pub fn development_config() -> ChainSpec {
     let endowed_balance = 50 * constants::currency::DOLLARS;
     let constructor = move || {
@@ -95,7 +115,6 @@ pub fn development_config() -> ChainSpec {
             true,
         )
     };
-    let network = NetworkType::Testnet;
     ChainSpec::from_genesis(
         "Development",
         "dev",
@@ -104,15 +123,7 @@ pub fn development_config() -> ChainSpec {
         vec![],
         None,
         Some("chainx-dev"),
-        Some(
-            json!({
-                "ss58Format": network.addr_version(),
-                "network": network,
-            })
-            .as_object()
-            .expect("must success")
-            .to_owned(),
-        ),
+        Some(as_properties(NetworkType::Testnet)),
         None,
     )
 }
@@ -145,7 +156,6 @@ pub fn local_testnet_config() -> ChainSpec {
             true,
         )
     };
-    let network = NetworkType::Testnet;
     ChainSpec::from_genesis(
         "Local Testnet",
         "local_testnet",
@@ -154,15 +164,7 @@ pub fn local_testnet_config() -> ChainSpec {
         vec![],
         None,
         Some("chainx-local-testnet"),
-        Some(
-            json!({
-                "ss58Format": network.addr_version(),
-                "network": network,
-            })
-            .as_object()
-            .expect("must success")
-            .to_owned(),
-        ),
+        Some(as_properties(NetworkType::Testnet)),
         None,
     )
 }
@@ -218,40 +220,30 @@ fn testnet_trustees() -> Vec<(
     TrusteeInfoConfig,
     Vec<(AccountId, Vec<u8>, Vec<u8>, Vec<u8>)>,
 )> {
+    macro_rules! btc_trustee {
+        ($btc_pubkey:expr) => {{
+            trustees::bitcoin::BtcTrusteeType::try_from(
+                hex::decode($btc_pubkey).expect("hex decode failed"),
+            )
+            .expect("btc trustee generation failed")
+        }};
+    }
     let alice = get_account_id_from_seed::<sr25519::Public>("Alice");
     let bob = get_account_id_from_seed::<sr25519::Public>("Bob");
     let charlie = get_account_id_from_seed::<sr25519::Public>("Charlie");
     let btc = Chain::Bitcoin;
-    let alice_hot = trustees::bitcoin::BtcTrusteeType::try_from(
-        hex::decode("035b8fb240f808f4d3d0d024fdf3b185b942e984bba81b6812b8610f66d59f3a84")
-            .expect(""),
-    )
-    .expect("");
-    let alice_cold = trustees::bitcoin::BtcTrusteeType::try_from(
-        hex::decode("0227e54b65612152485a812b8856e92f41f64788858466cc4d8df674939a5538c3")
-            .expect(""),
-    )
-    .expect("");
-    let bob_hot = trustees::bitcoin::BtcTrusteeType::try_from(
-        hex::decode("02a79800dfed17ad4c78c52797aa3449925692bc8c83de469421080f42d27790ee")
-            .expect(""),
-    )
-    .expect("");
-    let bob_cold = trustees::bitcoin::BtcTrusteeType::try_from(
-        hex::decode("020699bf931859cafdacd8ac4d3e055eae7551427487e281e3efba618bdd395f2f")
-            .expect(""),
-    )
-    .expect("");
-    let charlie_hot = trustees::bitcoin::BtcTrusteeType::try_from(
-        hex::decode("0306117a360e5dbe10e1938a047949c25a86c0b0e08a0a7c1e611b97de6b2917dd")
-            .expect(""),
-    )
-    .expect("");
-    let charlie_cold = trustees::bitcoin::BtcTrusteeType::try_from(
-        hex::decode("02a83c80e371ddf0a29006096765d060190bb607ec015ba6023b40ace582e13b99")
-            .expect(""),
-    )
-    .expect("");
+    let alice_hot =
+        btc_trustee!("035b8fb240f808f4d3d0d024fdf3b185b942e984bba81b6812b8610f66d59f3a84");
+    let alice_cold =
+        btc_trustee!("0227e54b65612152485a812b8856e92f41f64788858466cc4d8df674939a5538c3");
+    let bob_hot =
+        btc_trustee!("02a79800dfed17ad4c78c52797aa3449925692bc8c83de469421080f42d27790ee");
+    let bob_cold =
+        btc_trustee!("020699bf931859cafdacd8ac4d3e055eae7551427487e281e3efba618bdd395f2f");
+    let charlie_hot =
+        btc_trustee!("0306117a360e5dbe10e1938a047949c25a86c0b0e08a0a7c1e611b97de6b2917dd");
+    let charlie_cold =
+        btc_trustee!("02a83c80e371ddf0a29006096765d060190bb607ec015ba6023b40ace582e13b99");
 
     let about = b"".to_vec();
     let collection = vec![
@@ -280,7 +272,7 @@ fn session_keys(aura: AuraId, grandpa: GrandpaId, im_online: ImOnlineId) -> Sess
 }
 
 fn testnet_genesis(
-    initial_authorities: Vec<(AccountId, AccountId, AuraId, GrandpaId, ImOnlineId)>,
+    initial_authorities: Vec<AuthorityKeysTuple>,
     root_key: AccountId,
     assets: Vec<(AssetId, AssetInfo, AssetRestrictions, bool, bool)>,
     endowed: BTreeMap<AssetId, Vec<(AccountId, Balance)>>,
@@ -322,16 +314,11 @@ fn testnet_genesis(
         .collect();
 
     let validators = {
-        let staking_authorities = initial_authorities
-            .iter()
-            .map(|(s, _, _, _, _)| s)
-            .collect::<Vec<_>>();
-        balances
+        initial_authorities
             .clone()
             .into_iter()
-            .filter(|(v, _)| staking_authorities.contains(&v))
-            .map(|(v, _)| (v, STAKING_LOCKED))
-            .collect()
+            .map(|((v, r), _, _, _, _)| (v, r, STAKING_LOCKED))
+            .collect::<Vec<_>>()
     };
 
     GenesisConfig {
@@ -366,8 +353,8 @@ fn testnet_genesis(
                 .iter()
                 .map(|x| {
                     (
-                        x.0.clone(),
-                        x.0.clone(),
+                        (x.0).0.clone(),
+                        (x.0).0.clone(),
                         session_keys(x.2.clone(), x.3.clone(), x.4.clone()),
                     )
                 })
@@ -389,7 +376,7 @@ fn testnet_genesis(
         }),
         xpallet_assets: Some(XAssetsConfig {
             assets,
-            endowed: endowed.clone(),
+            endowed,
             memo_len: 128,
         }),
         xpallet_gateway_common: Some(XGatewayCommonConfig { trustees }),

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -59,6 +59,9 @@ pub type Precision = u8;
 pub type AddrStr = Vec<u8>;
 pub type AssetId = u32;
 
+/// Referral ID of validator.
+pub type ReferralId = Vec<u8>;
+
 /// App-specific crypto used for reporting equivocation/misbehavior in BABE and
 /// GRANDPA. Any rewards for misbehavior reporting will be paid out to this
 /// account.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -761,7 +761,7 @@ impl xpallet_mining_staking::Trait for Runtime {
 
 pub struct DummyReferralGetter;
 impl xpallet_mining_asset::GatewayInterface<AccountId> for DummyReferralGetter {
-    fn referral_of(_who: &AccountId) -> Option<AccountId> {
+    fn referral_of(_who: &AccountId, _asset_id: AssetId) -> Option<AccountId> {
         // FIXME impl this in gateway
         None
     }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -66,7 +66,7 @@ pub use pallet_transaction_payment::{Multiplier, TargetedFeeAdjustment};
 
 pub use chainx_primitives::{
     AccountId, AccountIndex, AddrStr, AssetId, Balance, BlockNumber, Hash, Index, Moment, Name,
-    Signature, Token,
+    ReferralId, Signature, Token,
 };
 pub use xp_runtime::Memo;
 

--- a/scripts/chainx-js/res/chainx_types.json
+++ b/scripts/chainx-js/res/chainx_types.json
@@ -124,7 +124,8 @@
     "ValidatorProfile": {
         "registeredAt": "BlockNumber",
         "isChilled": "bool",
-        "lastChilled": "Option<BlockNumber>"
+        "lastChilled": "Option<BlockNumber>",
+        "referralId": "ReferralId"
     },
     "NominatorProfile": {
         "lastRebond": "Option<BlockNumber>",
@@ -169,6 +170,7 @@
     "RpcBalance": "String",
     "RpcWeightType": "String",
     "WeightType": "u128",
+    "ReferralId": "Text",
     "AssetId": "u32",
     "Chain": {
         "_enum": [

--- a/scripts/chainx-js/types_gen.py
+++ b/scripts/chainx-js/types_gen.py
@@ -236,6 +236,8 @@ def parse_non_tuple_struct(lines, key):
     fields = lines[1:-1]
     fields_dict = {}
     for field in fields:
+        if field.strip().startswith('#[cfg'):
+            continue
         var = ''
         ty = ''
         for item in field.split():

--- a/xpallets/gateway/common/Cargo.toml
+++ b/xpallets/gateway/common/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.1", features = ["derive"], default-features = false }
+hex = { version = "0.4", optional = true }
 serde = { version = "1.0", optional = true }
 
 sp-std = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-rc4", default-features = false }
@@ -36,6 +37,7 @@ sp-core = { git = "https://github.com/paritytech/substrate.git", tag = "v2.0.0-r
 default = ["std"]
 std=[
     "codec/std",
+    "hex",
     "serde",
 
     "sp-std/std",

--- a/xpallets/gateway/common/src/trustees/bitcoin.rs
+++ b/xpallets/gateway/common/src/trustees/bitcoin.rs
@@ -1,7 +1,7 @@
 use super::*;
 use btc_keys::{Address, Public as BtcPublic};
 
-#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
+#[derive(PartialEq, Eq, Clone, Encode, Decode)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct BtcTrusteeAddrInfo {
@@ -9,6 +9,29 @@ pub struct BtcTrusteeAddrInfo {
     pub addr: Address,
     #[cfg_attr(feature = "std", serde(with = "xpallet_support::serde_impl::hex"))]
     pub redeem_script: Vec<u8>,
+}
+
+#[cfg(feature = "std")]
+impl std::fmt::Debug for BtcTrusteeAddrInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "BtcTrusteeAddrInfo {{ addr: {:?}, redeem_script: {} }}",
+            self.addr,
+            hex::encode(&self.redeem_script)
+        )
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl core::fmt::Debug for BtcTrusteeAddrInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "BtcTrusteeAddrInfo {{ addr: {:?}, redeem_script: {:?} }}",
+            self.addr, self.redeem_script
+        )
+    }
 }
 
 impl TryFrom<Vec<u8>> for BtcTrusteeAddrInfo {

--- a/xpallets/gateway/common/src/trustees/mod.rs
+++ b/xpallets/gateway/common/src/trustees/mod.rs
@@ -5,7 +5,6 @@ use codec::{Decode, Encode, Error as CodecError};
 use serde::{Deserialize, Serialize};
 // Substrate
 use frame_support::dispatch::DispatchError;
-use sp_runtime::RuntimeDebug;
 use sp_std::{convert::TryFrom, marker::PhantomData, prelude::Vec};
 
 use xpallet_assets::Chain;

--- a/xpallets/mining/asset/src/impls.rs
+++ b/xpallets/mining/asset/src/impls.rs
@@ -141,10 +141,11 @@ impl<T: Trait> Module<T> {
     fn allocate_dividend(
         claimee_reward_pot: &T::AccountId,
         claimer: &T::AccountId,
+        claimee: &AssetId,
         dividend: BalanceOf<T>,
     ) -> Result<(), Error<T>> {
         let to_referral_or_treasury = dividend / 10.saturated_into();
-        let reward_splitter = T::GatewayInterface::referral_of(claimer)
+        let reward_splitter = T::GatewayInterface::referral_of(claimer, *claimee)
             .unwrap_or_else(|| T::TreasuryAccount::treasury_account());
         Self::transfer(
             claimee_reward_pot,
@@ -186,7 +187,7 @@ impl<T: Trait> Claim<T::AccountId> for Module<T> {
 
         Self::has_enough_staking(claimer, dividend, staking_requirement)?;
 
-        Self::allocate_dividend(&claimee_reward_pot, claimer, dividend)?;
+        Self::allocate_dividend(&claimee_reward_pot, claimer, claimee, dividend)?;
 
         Self::apply_update_miner_mining_weight(claimer, claimee, 0, current_block);
         Self::apply_update_asset_mining_weight(

--- a/xpallets/mining/asset/src/lib.rs
+++ b/xpallets/mining/asset/src/lib.rs
@@ -75,11 +75,11 @@ where
 }
 
 pub trait GatewayInterface<AccountId> {
-    fn referral_of(who: &AccountId) -> Option<AccountId>;
+    fn referral_of(who: &AccountId, asset_id: AssetId) -> Option<AccountId>;
 }
 
 impl<AccountId> GatewayInterface<AccountId> for () {
-    fn referral_of(_: &AccountId) -> Option<AccountId> {
+    fn referral_of(_: &AccountId, _: AssetId) -> Option<AccountId> {
         None
     }
 }

--- a/xpallets/mining/asset/src/mock.rs
+++ b/xpallets/mining/asset/src/mock.rs
@@ -251,7 +251,7 @@ impl xp_mining_common::RewardPotAccountFor<AccountId, AssetId>
 pub struct DummyGatewayReferralGetter;
 
 impl GatewayInterface<AccountId> for DummyGatewayReferralGetter {
-    fn referral_of(who: &AccountId) -> Option<AccountId> {
+    fn referral_of(who: &AccountId, _: AssetId) -> Option<AccountId> {
         Some(10_000_000_000 + *who)
     }
 }
@@ -317,7 +317,12 @@ impl ExtBuilder {
         let validators = vec![1, 2, 3, 4];
 
         let _ = xpallet_mining_staking::GenesisConfig::<Test> {
-            validators: vec![(1, 10), (2, 20), (3, 30), (4, 40)],
+            validators: vec![
+                (1, b"1 ".to_vec(), 10),
+                (2, b"2 ".to_vec(), 20),
+                (3, b"3 ".to_vec(), 30),
+                (4, b"4 ".to_vec(), 40),
+            ],
             validator_count: 6,
             sessions_per_era: 3,
             vesting_account: VESTING_ACCOUNT,

--- a/xpallets/mining/asset/src/tests.rs
+++ b/xpallets/mining/asset/src/tests.rs
@@ -451,7 +451,8 @@ fn asset_mining_reward_should_work() {
             Balances::free_balance(&t_1),
             xbtc_pot_balance - xbtc_pot_balance / 10
         );
-        let referral = DummyGatewayReferralGetter::referral_of(&t_1).unwrap_or(TREASURY_ACCOUNT);
+        let referral = DummyGatewayReferralGetter::referral_of(&t_1, xpallet_protocol::X_BTC)
+            .unwrap_or(TREASURY_ACCOUNT);
         assert_eq!(Balances::free_balance(&referral), xbtc_pot_balance / 10);
         assert_eq!(Balances::free_balance(&TREASURY_ACCOUNT), treasury_balance);
     });

--- a/xpallets/mining/staking/src/lib.rs
+++ b/xpallets/mining/staking/src/lib.rs
@@ -266,6 +266,8 @@ decl_error! {
         NotValidator,
         /// The account is already registered as a validator.
         AlreadyValidator,
+        /// The validators count already reaches `MaximumValidatorCount`.
+        TooManyValidators,
         /// The validator can accept no more votes from other voters.
         NoMoreAcceptableVotes,
         /// The validator can not (forcedly) be chilled due to the limit of minimal validators count.
@@ -436,6 +438,10 @@ decl_module! {
             let sender = ensure_signed(origin)?;
             Self::check_referral_id(&referral_id)?;
             ensure!(!Self::is_validator(&sender), Error::<T>::AlreadyValidator);
+            ensure!(
+                (Self::validator_set().count() as u32) < MaximumValidatorCount::get(),
+                Error::<T>::TooManyValidators
+            );
             Self::apply_register(&sender, referral_id);
         }
 

--- a/xpallets/mining/staking/src/lib.rs
+++ b/xpallets/mining/staking/src/lib.rs
@@ -759,6 +759,7 @@ impl<T: Trait> Module<T> {
 
     fn apply_register(who: &T::AccountId, referral_id: ReferralId) {
         let current_block = <frame_system::Module<T>>::block_number();
+        ValidatorFor::<T>::insert(&referral_id, who.clone());
         Validators::<T>::insert(
             who,
             ValidatorProfile {

--- a/xpallets/mining/staking/src/lib.rs
+++ b/xpallets/mining/staking/src/lib.rs
@@ -29,6 +29,7 @@ use sp_runtime::{
 use sp_std::collections::btree_map::BTreeMap;
 use sp_std::prelude::*;
 
+use chainx_primitives::ReferralId;
 use xp_mining_common::{
     Claim, ComputeMiningWeight, Delta, RewardPotAccountFor, ZeroMiningWeightError,
 };
@@ -134,6 +135,9 @@ decl_storage! {
         /// The beneficiary account of vesting schedule.
         pub VestingAccount get(fn vesting_account) config(): T::AccountId;
 
+        /// The validator account behind the referral id.
+        pub ValidatorFor: map hasher(twox_64_concat) ReferralId => Option<T::AccountId>;
+
         /// Maximum value of total_bonded/self_bonded.
         pub UpperBoundFactorOfAcceptableVotes get(fn upper_bound_factor) config():
             u32 = 10u32;
@@ -200,16 +204,17 @@ decl_storage! {
 
     add_extra_genesis {
         config(validators):
-            Vec<(T::AccountId, BalanceOf<T>)>;
+            Vec<(T::AccountId, ReferralId, BalanceOf<T>)>;
         config(glob_dist_ratio): (u32, u32);
         config(mining_ratio): (u32, u32);
         build(|config: &GenesisConfig<T>| {
-            for &(ref v, balance) in &config.validators {
+            for &(ref v, ref referral_id, balance) in &config.validators {
                 assert!(
                     Module::<T>::free_balance(v) >= balance,
                     "Validator does not have enough balance to bond."
                 );
-                Module::<T>::apply_register(v);
+                Module::<T>::check_referral_id(referral_id).expect("Invalid referral_id in genesis");
+                Module::<T>::apply_register(v, referral_id.to_vec());
                 Module::<T>::apply_bond(v, v, balance).expect("Staking genesis initialization can not fail");
             }
             assert!(config.glob_dist_ratio.0 + config.glob_dist_ratio.1 > 0);
@@ -283,6 +288,12 @@ decl_error! {
         InvalidUnbondedIndex,
         /// The unbonded balances are still in the locked state.
         UnbondedWithdrawalNotYetDue,
+        /// The length of referral identity is either too long or too short.
+        InvalidReferralIdentityLength,
+        /// The referral identity has been claimed by someone else.
+        OccupiedReferralIdentity,
+        /// Failed to pass the xss check.
+        XssCheckFailed,
     }
 }
 
@@ -421,10 +432,11 @@ decl_module! {
 
         /// Register to be a validator for the origin account.
         #[weight = 100_000]
-        pub fn register(origin) {
+        pub fn register(origin, referral_id: ReferralId) {
             let sender = ensure_signed(origin)?;
+            Self::check_referral_id(&referral_id)?;
             ensure!(!Self::is_validator(&sender), Error::<T>::AlreadyValidator);
-            Self::apply_register(&sender);
+            Self::apply_register(&sender, referral_id);
         }
 
         #[weight = 10]
@@ -500,21 +512,31 @@ impl<T: Trait> Module<T> {
         Validators::<T>::contains_key(who)
     }
 
+    /// Returns the (possible) validator account behind the given referral id.
+    #[inline]
+    pub fn validator_for(referral_id: &[u8]) -> Option<T::AccountId> {
+        ValidatorFor::<T>::get(referral_id)
+    }
+
+    /// Return true if the validator `who` is chilled.
     #[inline]
     pub fn is_chilled(who: &T::AccountId) -> bool {
         Validators::<T>::get(who).is_chilled
     }
 
+    /// Return true if the validator `who` is not chilled.
     #[inline]
     pub fn is_active(who: &T::AccountId) -> bool {
         !Self::is_chilled(who)
     }
 
+    /// Returns all the registered validators in Staking.
     #[inline]
     pub fn validator_set() -> impl Iterator<Item = T::AccountId> {
         Validators::<T>::iter().map(|(v, _)| v)
     }
 
+    /// Returns all the validators that are not chilled.
     #[inline]
     pub fn active_validator_set() -> impl Iterator<Item = T::AccountId> {
         Self::validator_set().filter(Self::is_active)
@@ -534,6 +556,7 @@ impl<T: Trait> Module<T> {
         *Self::locks(who).entry(LockedType::Bonded).or_default()
     }
 
+    /// Returns the associated reward pot account for the given validator.
     #[inline]
     pub fn reward_pot_for(validator: &T::AccountId) -> T::AccountId {
         T::DetermineRewardPotAccount::reward_pot_account_for(validator)
@@ -599,6 +622,25 @@ impl<T: Trait> Module<T> {
 
     fn acceptable_votes_limit_of(validator: &T::AccountId) -> BalanceOf<T> {
         Self::validator_self_bonded(validator) * BalanceOf::<T>::from(Self::upper_bound_factor())
+    }
+
+    fn check_referral_id(referral_id: &[u8]) -> Result<(), Error<T>> {
+        const MIMUM_REFERRAL_ID: usize = 2;
+        const MAXIMUM_REFERRAL_ID: usize = 12;
+        let referral_id_len = referral_id.len();
+        ensure!(
+            referral_id_len >= MIMUM_REFERRAL_ID && referral_id_len <= MAXIMUM_REFERRAL_ID,
+            Error::<T>::InvalidReferralIdentityLength
+        );
+        ensure!(
+            xp_runtime::xss_check(referral_id).is_ok(),
+            Error::<T>::XssCheckFailed
+        );
+        ensure!(
+            Self::validator_for(referral_id).is_none(),
+            Error::<T>::OccupiedReferralIdentity
+        );
+        Ok(())
     }
 
     /// Returns Ok if the validator can still accept the `value` of new votes.
@@ -715,12 +757,13 @@ impl<T: Trait> Module<T> {
         Self::set_validator_vote_weight(target, target_weight, current_block, delta);
     }
 
-    fn apply_register(who: &T::AccountId) {
+    fn apply_register(who: &T::AccountId, referral_id: ReferralId) {
         let current_block = <frame_system::Module<T>>::block_number();
         Validators::<T>::insert(
             who,
             ValidatorProfile {
                 registered_at: current_block,
+                referral_id,
                 ..Default::default()
             },
         );

--- a/xpallets/mining/staking/src/mock.rs
+++ b/xpallets/mining/staking/src/mock.rs
@@ -252,7 +252,12 @@ impl ExtBuilder {
         let validators = vec![1, 2, 3, 4];
 
         let _ = GenesisConfig::<Test> {
-            validators: vec![(1, 10), (2, 20), (3, 30), (4, 40)],
+            validators: vec![
+                (1, b"1 ".to_vec(), 10),
+                (2, b"2 ".to_vec(), 20),
+                (3, b"3 ".to_vec(), 30),
+                (4, b"4 ".to_vec(), 40),
+            ],
             validator_count: 6,
             sessions_per_era: 3,
             vesting_account: VESTING_ACCOUNT,

--- a/xpallets/mining/staking/src/tests.rs
+++ b/xpallets/mining/staking/src/tests.rs
@@ -709,3 +709,22 @@ fn balances_reserve_should_work() {
         );
     });
 }
+
+#[test]
+fn referral_id_should_work() {
+    ExtBuilder::default().build_and_execute(|| {
+        assert_ok!(XStaking::register(
+            Origin::signed(111),
+            b"referral1".to_vec()
+        ));
+        assert_err!(
+            XStaking::register(Origin::signed(112), b"referral1".to_vec()),
+            Error::<Test>::OccupiedReferralIdentity
+        );
+
+        assert_ok!(XStaking::register(
+            Origin::signed(112),
+            b"referral2".to_vec()
+        ));
+    });
+}

--- a/xpallets/mining/staking/src/tests.rs
+++ b/xpallets/mining/staking/src/tests.rs
@@ -7,7 +7,13 @@ fn t_issue_pcx(to: AccountId, value: Balance) {
 }
 
 fn t_register(who: AccountId) -> DispatchResult {
-    XStaking::register(Origin::signed(who))
+    let mut referral_id = who.to_string().as_bytes().to_vec();
+
+    if referral_id.len() < 2 {
+        referral_id.extend_from_slice(&[0, 0, 0, who as u8]);
+    }
+
+    XStaking::register(Origin::signed(who), referral_id)
 }
 
 fn t_bond(who: AccountId, target: AccountId, value: Balance) -> DispatchResult {

--- a/xpallets/mining/staking/src/types.rs
+++ b/xpallets/mining/staking/src/types.rs
@@ -127,6 +127,9 @@ pub struct ValidatorProfile<BlockNumber> {
     pub is_chilled: bool,
     /// Block number of last performed `chill` operation.
     pub last_chilled: Option<BlockNumber>,
+    /// Referral identity that belongs to the validator.
+    #[cfg_attr(feature = "std", serde(with = "xpallet_support::serde_impl::text"))]
+    pub referral_id: ReferralId,
 }
 
 /// Profile of staking nominator.


### PR DESCRIPTION
- Introduce `referral_id` for validator.
- Remove the old PCX endowed info in genesis for XAssets.

TODO:
- [x] Update RPC docs. https://github.com/chainx-org/documentation/pull/5
- [x] Update chainx_types.