### PR TITLE
Allow updating trading pair

### DIFF
--- a/xrml/xdex/spot/src/tests.rs
+++ b/xrml/xdex/spot/src/tests.rs
@@ -33,9 +33,21 @@ fn update_trading_pair_should_work() {
         assert_eq!(XSpot::trading_pair_of(2).unwrap().tick_precision, 1);
         assert_eq!(XSpot::trading_pair_of(2).unwrap().online, true);
 
-        assert_ok!(XSpot::update_trading_pair(2, 888, false));
+        assert_ok!(XSpot::update_trading_pair(2, Some(888), false));
         assert_eq!(XSpot::trading_pair_of(2).unwrap().tick_precision, 888);
         assert_eq!(XSpot::trading_pair_of(2).unwrap().online, false);
+
+        assert_noop!(
+            XSpot::put_order(
+                Origin::signed(1),
+                2,
+                OrderType::Limit,
+                Side::Sell,
+                1000,
+                890_000,
+            ),
+            "The trading pair must be online"
+        );
     })
 }
 


### PR DESCRIPTION
~~According to the proposal 11, the current SDOT trading pair needs to be canceled.~~

Closing as we decided to take another approach: `modify_asset_limit(b"SDOT".to_vec(), AssetLimit::CanMove, false)`.