### PR TITLE
Consider the migration offset of session reward

### DIFF
--- a/cli/src/chain_spec.rs
+++ b/cli/src/chain_spec.rs
@@ -426,7 +426,6 @@ fn testnet_genesis(
         xpallet_mining_staking: Some(XStakingConfig {
             validators,
             validator_count: 1000,
-            minimum_validator_count: 4,
             sessions_per_era: 12,
             vesting_account: get_account_id_from_seed::<sr25519::Public>("vesting"),
             glob_dist_ratio: (12, 88), // (Treasury, X-type Asset and Staking) = (12, 88)

--- a/xpallets/mining/staking/src/constants.rs
+++ b/xpallets/mining/staking/src/constants.rs
@@ -13,9 +13,6 @@ pub const INITIAL_REWARD: u64 = 5_000_000_000;
 /// is equivalent to `Block` in Bitcoin with regard to minting new coins.
 pub const SESSIONS_PER_ROUND: u32 = 210_000;
 
-/// FIXME remove this item.
-pub const DEFAULT_MINIMUM_VALIDATOR_COUNT: u32 = 4;
-
 /// The maximum number of Staking validators.
 ///
 /// Currently the election will perform a naive sort on the all candidates,

--- a/xpallets/mining/staking/src/constants.rs
+++ b/xpallets/mining/staking/src/constants.rs
@@ -1,0 +1,45 @@
+use frame_support::traits::LockIdentifier;
+
+pub const STAKING_ID: LockIdentifier = *b"staking ";
+
+/// Session reward of the first 210_000 sessions.
+///
+/// ChainX uses a Bitcoin like issuance model, the initial reward is 50 PCX.
+pub const INITIAL_REWARD: u64 = 5_000_000_000;
+
+/// Every 210_000 sessions, the session reward is cut in half.
+///
+/// ChainX follows the issuance rule of Bitcoin. The `Session` in ChainX
+/// is equivalent to `Block` in Bitcoin with regard to minting new coins.
+pub const SESSIONS_PER_ROUND: u32 = 210_000;
+
+/// FIXME remove this item.
+pub const DEFAULT_MINIMUM_VALIDATOR_COUNT: u32 = 4;
+
+/// The maximum number of Staking validators.
+///
+/// Currently the election will perform a naive sort on the all candidates,
+/// so we don't want the candidate list too huge.
+pub const DEFAULT_MAXIMUM_VALIDATOR_COUNT: u32 = 1000;
+
+/// The maximum number of ongoing unbonded operations in parallel.
+pub const DEFAULT_MAXIMUM_UNBONDED_CHUNK_SIZE: u32 = 10;
+
+/// ChainX 2.0's block time is targeted at 6s, i.e., 5 minutes per session.
+///
+/// ChainX 1.0 is 2s/block, 150 blocks/session, the duration of each session is also
+/// 5 minutes, therefore the issuance rate stays the same in terms of the time dimension, the daily Staking earnings does not change.
+pub const DEFAULT_BLOCKS_PER_SESSION: u64 = 50;
+
+/// The default bonding duration for regular staker is 3 days.
+///
+/// The staker can unbond the staked balances, but these balances will be free immediately, they have to wait for 3 days to withdraw them into the free balances.
+pub const DEFAULT_BONDING_DURATION: u64 = DEFAULT_BLOCKS_PER_SESSION * 12 * 24 * 3;
+
+/// The default bonding duration for validator is 3 * 10 days.
+pub const DEFAULT_VALIDATOR_BONDING_DURATION: u64 = DEFAULT_BONDING_DURATION * 10;
+
+/// The number of unfinished sessions in the first halving epoch.
+///
+/// When the ChainX 2.0 migration happens, the first halving epoch is still not due.
+pub const MIGRATION_SESSION_OFFSET: u32 = 500;

--- a/xpallets/mining/staking/src/constants.rs
+++ b/xpallets/mining/staking/src/constants.rs
@@ -41,5 +41,5 @@ pub const DEFAULT_VALIDATOR_BONDING_DURATION: u64 = DEFAULT_BONDING_DURATION * 1
 
 /// The number of unfinished sessions in the first halving epoch.
 ///
-/// When the ChainX 2.0 migration happens, the first halving epoch is still not due.
+/// When the ChainX 2.0 migration happens, the first halving epoch is not over yet.
 pub const MIGRATION_SESSION_OFFSET: u32 = 500;

--- a/xpallets/mining/staking/src/election.rs
+++ b/xpallets/mining/staking/src/election.rs
@@ -68,7 +68,7 @@ impl<T: Trait> Module<T> {
 
         // Avoid reevaluate validator set if it would leave us with fewer than the minimum
         // needed validators.
-        if candidates.len() < Self::minimum_validator_count() as usize {
+        if candidates.len() < Self::reasonable_minimum_validator_count() as usize {
             return None;
         }
 

--- a/xpallets/mining/staking/src/lib.rs
+++ b/xpallets/mining/staking/src/lib.rs
@@ -654,6 +654,7 @@ impl<T: Trait> Module<T> {
         }
     }
 
+    /// At least one validator is required.
     fn reasonable_minimum_validator_count() -> u32 {
         Self::minimum_validator_count().max(1)
     }

--- a/xpallets/mining/staking/src/lib.rs
+++ b/xpallets/mining/staking/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+mod constants;
 mod election;
 mod impls;
 mod reward;
@@ -17,9 +18,7 @@ mod tests;
 use frame_support::{
     decl_error, decl_event, decl_module, decl_storage, ensure,
     storage::IterableStorageMap,
-    traits::{
-        Currency, ExistenceRequirement, Get, LockIdentifier, LockableCurrency, WithdrawReasons,
-    },
+    traits::{Currency, ExistenceRequirement, Get, LockableCurrency, WithdrawReasons},
 };
 use frame_system::{self as system, ensure_root, ensure_signed};
 use sp_runtime::{
@@ -30,6 +29,7 @@ use sp_std::collections::btree_map::BTreeMap;
 use sp_std::prelude::*;
 
 use chainx_primitives::ReferralId;
+use constants::*;
 use xp_mining_common::{
     Claim, ComputeMiningWeight, Delta, RewardPotAccountFor, ZeroMiningWeightError,
 };
@@ -43,26 +43,6 @@ pub use types::*;
 
 pub type BalanceOf<T> =
     <<T as Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::Balance;
-
-const STAKING_ID: LockIdentifier = *b"staking ";
-
-/// Session reward of the first 210_000 sessions.
-const INITIAL_REWARD: u64 = 5_000_000_000;
-
-/// Every 210_000 sessions, the session reward is cut in half.
-///
-/// ChainX follows the issuance rule of Bitcoin. The `Session` in ChainX
-/// is equivalent to `Block` in Bitcoin with regard to minting new coins.
-const SESSIONS_PER_ROUND: u32 = 210_000;
-
-const DEFAULT_MINIMUM_VALIDATOR_COUNT: u32 = 4;
-const DEFAULT_MAXIMUM_VALIDATOR_COUNT: u32 = 100;
-const DEFAULT_MAXIMUM_UNBONDED_CHUNK_SIZE: u32 = 10;
-
-/// ChainX 2.0 block time is targeted at 6s, i.e., 5 minute per session by default.
-const DEFAULT_BLOCKS_PER_SESSION: u64 = 50;
-const DEFAULT_BONDING_DURATION: u64 = DEFAULT_BLOCKS_PER_SESSION * 12 * 24 * 3;
-const DEFAULT_VALIDATOR_BONDING_DURATION: u64 = DEFAULT_BONDING_DURATION * 10;
 
 /// Counter for the number of eras that have passed.
 pub type EraIndex = u32;

--- a/xpallets/mining/staking/src/lib.rs
+++ b/xpallets/mining/staking/src/lib.rs
@@ -81,8 +81,7 @@ decl_storage! {
         pub ValidatorCount get(fn validator_count) config(): u32;
 
         /// Minimum number of staking participants before emergency conditions are imposed.
-        pub MinimumValidatorCount get(fn minimum_validator_count) config():
-            u32 = DEFAULT_MINIMUM_VALIDATOR_COUNT;
+        pub MinimumValidatorCount get(fn minimum_validator_count) config(): u32;
 
         /// Maximum number of staking participants before emergency conditions are imposed.
         pub MaximumValidatorCount get(fn maximum_validator_count) config():
@@ -655,10 +654,14 @@ impl<T: Trait> Module<T> {
         }
     }
 
+    fn reasonable_minimum_validator_count() -> u32 {
+        Self::minimum_validator_count().max(1)
+    }
+
     /// Returns true if the number of active validators are more than the minimum validator count.
     fn can_force_chilled() -> bool {
         let mut active_cnt = 0u32;
-        let minimum_validator_cnt = Self::minimum_validator_count();
+        let minimum_validator_cnt = Self::reasonable_minimum_validator_count();
         Self::validator_set()
             .try_for_each(|v| {
                 if Self::is_active(&v) {

--- a/xpallets/mining/staking/src/reward/mod.rs
+++ b/xpallets/mining/staking/src/reward/mod.rs
@@ -12,11 +12,12 @@ impl<T: Trait> Module<T> {
     }
 
     /// Returns the total reward for the session, assuming it ends with this block.
-    ///
-    /// Due to the migration of ChainX 1.0 to ChainX 2.0,
-    fn this_session_reward(current_index: SessionIndex) -> BalanceOf<T> {
-        let halving_epoch = current_index / SESSIONS_PER_ROUND;
-        // FIXME: migration_offset
+    pub(crate) fn this_session_reward(current_index: SessionIndex) -> BalanceOf<T> {
+        let halving_epoch = if current_index <= MIGRATION_SESSION_OFFSET {
+            0
+        } else {
+            (current_index - MIGRATION_SESSION_OFFSET - 1) / SESSIONS_PER_ROUND + 1
+        };
         let reward = INITIAL_REWARD.saturated_into::<BalanceOf<T>>() / Self::pow2(halving_epoch);
         reward
     }

--- a/xpallets/mining/staking/src/slashing.rs
+++ b/xpallets/mining/staking/src/slashing.rs
@@ -31,7 +31,7 @@ impl<T: Trait> Module<T> {
         let treasury_account = T::TreasuryAccount::treasury_account();
         let slasher = Slasher::<T>::new(treasury_account);
 
-        let minimum_validator_count = Self::minimum_validator_count() as usize;
+        let minimum_validator_count = Self::reasonable_minimum_validator_count() as usize;
 
         let active_validators = Self::active_validator_set().collect::<Vec<_>>();
         let mut active_count = active_validators.len();

--- a/xpallets/mining/staking/src/tests.rs
+++ b/xpallets/mining/staking/src/tests.rs
@@ -728,3 +728,36 @@ fn referral_id_should_work() {
         ));
     });
 }
+
+#[test]
+fn migration_session_offset_should_work() {
+    ExtBuilder::default().build_and_execute(|| {
+        let test_cases = vec![
+            (MIGRATION_SESSION_OFFSET, INITIAL_REWARD),
+            (MIGRATION_SESSION_OFFSET + 1, INITIAL_REWARD / 2),
+            (
+                MIGRATION_SESSION_OFFSET + SESSIONS_PER_ROUND,
+                INITIAL_REWARD / 2,
+            ),
+            (
+                MIGRATION_SESSION_OFFSET + SESSIONS_PER_ROUND + 1,
+                INITIAL_REWARD / 4,
+            ),
+            (
+                MIGRATION_SESSION_OFFSET + SESSIONS_PER_ROUND * 2,
+                INITIAL_REWARD / 4,
+            ),
+            (
+                MIGRATION_SESSION_OFFSET + SESSIONS_PER_ROUND * 2 + 1,
+                INITIAL_REWARD / 8,
+            ),
+        ];
+
+        for (session_index, session_reward) in test_cases {
+            assert_eq!(
+                XStaking::this_session_reward(session_index),
+                session_reward as Balance
+            );
+        }
+    });
+}

--- a/xpallets/mining/staking/src/tests.rs
+++ b/xpallets/mining/staking/src/tests.rs
@@ -89,6 +89,9 @@ fn cannot_force_chill_should_work() {
         t_make_a_validator_candidate(123, 100);
         assert_eq!(XStaking::can_force_chilled(), true);
         assert_ok!(XStaking::chill(Origin::signed(123)));
+        assert_ok!(XStaking::chill(Origin::signed(2)));
+        assert_ok!(XStaking::chill(Origin::signed(3)));
+        assert_ok!(XStaking::chill(Origin::signed(4)));
         assert_err!(
             XStaking::chill(Origin::signed(1)),
             <Error<Test>>::TooFewActiveValidators


### PR DESCRIPTION
- Consider the session offset set of first halving epoch due to the 2.0 migration.
- Remove the `MinimumValidatorCount` const, close #182.