### PR TITLE
Add reserved balance in Spot order rpc

### DIFF
--- a/scripts/chainx-js/chainx_types_manual.json
+++ b/scripts/chainx-js/chainx_types_manual.json
@@ -237,6 +237,14 @@
         "last_vote_weight_update": "BlockNumber",
         "unbonded_chunks": "Vec<RpcUnbonded>"
     },
+    "MiningAssetInfo": {
+        "asset_id": "AssetId",
+        "mining_power": "FixedAssetPower",
+        "reward_pot": "AccountId",
+        "reward_pot_balance": "RpcBalance",
+        "last_total_mining_weight": "RpcWeightType",
+        "last_total_mining_weight_update": "BlockNumber"
+    },
     "Unbonded": {
         "value": "Balance",
         "locked_until": "BlockNumber"

--- a/scripts/chainx-js/chainx_types_manual.json
+++ b/scripts/chainx-js/chainx_types_manual.json
@@ -245,6 +245,11 @@
         "asks": "Vec<(RpcPrice, RpcBalance)>",
         "bids": "Vec<(RpcPrice, RpcBalance)>"
     },
+    "Page": {
+        "page_index": "u32",
+        "page_size": "u32",
+        "data": "Vec<RpcOrder>"
+    },
     "String": "Text",
     "RpcPrice": "String",
     "RpcBalance": "String",

--- a/scripts/chainx-js/res/chainx_types.json
+++ b/scripts/chainx-js/res/chainx_types.json
@@ -118,7 +118,8 @@
         "miningPower": "FixedAssetPower",
         "rewardPot": "AccountId",
         "rewardPotBalance": "RpcBalance",
-        "ledgerInfo": "RpcAssetLedger<BlockNumber>"
+        "lastTotalMiningWeight": "RpcWeightType",
+        "lastTotalMiningWeightUpdate": "BlockNumber"
     },
     "AssetLedger": {
         "lastTotalMiningWeight": "MiningWeight",

--- a/xpallets/assets-registrar/src/lib.rs
+++ b/xpallets/assets-registrar/src/lib.rs
@@ -11,6 +11,7 @@ mod benchmarking;
 #[cfg(test)]
 mod tests;
 mod verifier;
+mod weight_info;
 
 use sp_std::{prelude::*, result, slice::Iter};
 
@@ -23,7 +24,6 @@ use frame_support::{
     dispatch::{DispatchError, DispatchResult},
     ensure,
     traits::Get,
-    weights::Weight,
     IterableStorageMap, RuntimeDebug,
 };
 use frame_system::ensure_root;
@@ -33,29 +33,8 @@ use chainx_primitives::{AssetId, Decimals, Desc, Token};
 use xpallet_support::info;
 
 pub use verifier::*;
+pub use weight_info::WeightInfo;
 pub use xp_assets_registrar::RegistrarHandler;
-
-pub trait WeightInfo {
-    fn register() -> Weight;
-    fn deregister() -> Weight;
-    fn recover() -> Weight;
-    fn update_asset_info() -> Weight;
-}
-
-impl WeightInfo for () {
-    fn register() -> Weight {
-        1_000_000_000
-    }
-    fn deregister() -> Weight {
-        1_000_000_000
-    }
-    fn recover() -> Weight {
-        1_000_000_000
-    }
-    fn update_asset_info() -> Weight {
-        1_000_000_000
-    }
-}
 
 #[derive(PartialEq, Eq, Ord, PartialOrd, Clone, Copy, Encode, Decode, RuntimeDebug)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]

--- a/xpallets/assets-registrar/src/weight_info.rs
+++ b/xpallets/assets-registrar/src/weight_info.rs
@@ -1,0 +1,23 @@
+use frame_support::weights::Weight;
+
+pub trait WeightInfo {
+    fn register() -> Weight;
+    fn deregister() -> Weight;
+    fn recover() -> Weight;
+    fn update_asset_info() -> Weight;
+}
+
+impl WeightInfo for () {
+    fn register() -> Weight {
+        1_000_000_000
+    }
+    fn deregister() -> Weight {
+        1_000_000_000
+    }
+    fn recover() -> Weight {
+        1_000_000_000
+    }
+    fn update_asset_info() -> Weight {
+        1_000_000_000
+    }
+}

--- a/xpallets/dex/spot/src/execution/order.rs
+++ b/xpallets/dex/spot/src/execution/order.rs
@@ -71,7 +71,7 @@ impl<T: Trait> Module<T> {
         // The order count of user should be increased after a new order is created.
         <OrderCountOf<T>>::insert(&who, order_id + 1);
 
-        Self::deposit_event(RawEvent::PutOrder(order.clone()));
+        Self::deposit_event(RawEvent::NewOrder(order.clone()));
 
         order
     }
@@ -380,8 +380,8 @@ impl<T: Trait> Module<T> {
         Self::insert_executed_order(maker_order);
         Self::insert_executed_order(taker_order);
 
-        Self::deposit_event(RawEvent::UpdateMakerOrder(maker_order.clone()));
-        Self::deposit_event(RawEvent::UpdateTakerOrder(taker_order.clone()));
+        Self::deposit_event(RawEvent::MakerOrderUpdated(maker_order.clone()));
+        Self::deposit_event(RawEvent::TakerOrderUpdated(taker_order.clone()));
         Self::deposit_event(RawEvent::OrderExecuted(OrderExecutedInfo::new(
             trading_history_idx,
             pair_id,
@@ -414,7 +414,7 @@ impl<T: Trait> Module<T> {
 
         OrderInfoOf::<T>::insert(order.submitter(), order.id(), order.clone());
 
-        Self::deposit_event(RawEvent::UpdateCanceledOrder(order.clone()));
+        Self::deposit_event(RawEvent::CanceledOrderUpdated(order.clone()));
 
         Ok(())
     }

--- a/xpallets/dex/spot/src/lib.rs
+++ b/xpallets/dex/spot/src/lib.rs
@@ -155,17 +155,17 @@ decl_event!(
         <T as Trait>::Price,
     {
         /// A new order is created.
-        PutOrder(Order<TradingPairId, AccountId, Balance, Price, BlockNumber>),
+        NewOrder(Order<TradingPairId, AccountId, Balance, Price, BlockNumber>),
         /// There is an update to the order due to it gets executed.
-        UpdateMakerOrder(Order<TradingPairId, AccountId, Balance, Price, BlockNumber>),
+        MakerOrderUpdated(Order<TradingPairId, AccountId, Balance, Price, BlockNumber>),
         /// There is an update to the order due to it gets executed.
-        UpdateTakerOrder(Order<TradingPairId, AccountId, Balance, Price, BlockNumber>),
+        TakerOrderUpdated(Order<TradingPairId, AccountId, Balance, Price, BlockNumber>),
         /// Overall information about the maker and taker orders when there is an order execution.
         OrderExecuted(OrderExecutedInfo<AccountId, Balance, BlockNumber, Price>),
         /// There is an update to the order due to it gets canceled.
-        UpdateCanceledOrder(Order<TradingPairId, AccountId, Balance, Price, BlockNumber>),
+        CanceledOrderUpdated(Order<TradingPairId, AccountId, Balance, Price, BlockNumber>),
         /// A new trading pair is added.
-        AddTradingPair(TradingPairProfile),
+        TradingPairAdded(TradingPairProfile),
         /// Trading pair profile has been updated.
         TradingPairUpdated(TradingPairProfile),
         /// Price fluctuation of trading pair has been updated.
@@ -398,7 +398,7 @@ impl<T: Trait> Module<T> {
 
         TradingPairCount::put(pair_id + 1);
 
-        Self::deposit_event(RawEvent::AddTradingPair(pair));
+        Self::deposit_event(RawEvent::TradingPairAdded(pair));
     }
 
     fn apply_update_trading_pair(pair_id: TradingPairId, tick_decimals: u32, tradable: bool) {

--- a/xpallets/dex/spot/src/lib.rs
+++ b/xpallets/dex/spot/src/lib.rs
@@ -189,10 +189,14 @@ decl_event!(
     {
         /// A new order is created.
         PutOrder(Order<TradingPairId, AccountId, Balance, Price, BlockNumber>),
-        /// There is an update to the order due to it's canceled or get executed.
-        UpdateOrder(Order<TradingPairId, AccountId, Balance, Price, BlockNumber>),
-        /// The order gets executed.
+        /// There is an update to the order due to it gets executed.
+        UpdateMakerOrder(Order<TradingPairId, AccountId, Balance, Price, BlockNumber>),
+        /// There is an update to the order due to it gets executed.
+        UpdateTakerOrder(Order<TradingPairId, AccountId, Balance, Price, BlockNumber>),
+        /// Overall information about the maker and taker orders when there is an order execution.
         OrderExecuted(OrderExecutedInfo<AccountId, Balance, BlockNumber, Price>),
+        /// There is an update to the order due to it gets canceled.
+        UpdateCanceledOrder(Order<TradingPairId, AccountId, Balance, Price, BlockNumber>),
         /// A new trading pair is added.
         AddTradingPair(TradingPairProfile),
         /// Trading pair profile has been updated.

--- a/xpallets/dex/spot/src/lib.rs
+++ b/xpallets/dex/spot/src/lib.rs
@@ -5,6 +5,7 @@
 mod execution;
 mod rpc;
 mod types;
+mod weight_info;
 
 #[cfg(any(feature = "runtime-benchmarks", test))]
 mod benchmarking;
@@ -27,7 +28,6 @@ use frame_support::{
     dispatch::{DispatchError, DispatchResult},
     ensure,
     traits::{Currency, Get, ReservableCurrency},
-    weights::Weight,
     Parameter,
 };
 use frame_system::{ensure_root, ensure_signed};
@@ -38,6 +38,7 @@ use xpallet_support::info;
 
 pub use rpc::*;
 pub use types::*;
+pub use weight_info::WeightInfo;
 
 /// Maximum of backlog orders.
 const MAX_BACKLOG_ORDER: usize = 1000;
@@ -58,39 +59,15 @@ pub type BalanceOf<T> = <<T as xpallet_assets::Trait>::Currency as Currency<
     <T as frame_system::Trait>::AccountId,
 >>::Balance;
 
-pub trait WeightInfo {
-    fn put_order() -> Weight;
-    fn cancel_order() -> Weight;
-    fn force_cancel_order() -> Weight;
-    fn set_handicap() -> Weight;
-    fn set_price_fluctuation() -> Weight;
-    fn add_trading_pair() -> Weight;
-    fn update_trading_pair() -> Weight;
-}
+pub type OrderInfo<T> = Order<
+    TradingPairId,
+    <T as frame_system::Trait>::AccountId,
+    BalanceOf<T>,
+    <T as Trait>::Price,
+    <T as frame_system::Trait>::BlockNumber,
+>;
 
-impl WeightInfo for () {
-    fn put_order() -> Weight {
-        1_000_000_000
-    }
-    fn cancel_order() -> Weight {
-        1_000_000_000
-    }
-    fn force_cancel_order() -> Weight {
-        1_000_000_000
-    }
-    fn set_handicap() -> Weight {
-        1_000_000_000
-    }
-    fn set_price_fluctuation() -> Weight {
-        1_000_000_000
-    }
-    fn add_trading_pair() -> Weight {
-        1_000_000_000
-    }
-    fn update_trading_pair() -> Weight {
-        1_000_000_000
-    }
-}
+pub type HandicapInfo<T> = Handicap<<T as Trait>::Price>;
 
 pub trait Trait: xpallet_assets::Trait {
     /// The overarching event type.
@@ -108,16 +85,6 @@ pub trait Trait: xpallet_assets::Trait {
 
     type WeightInfo: WeightInfo;
 }
-
-pub type OrderInfo<T> = Order<
-    TradingPairId,
-    <T as frame_system::Trait>::AccountId,
-    BalanceOf<T>,
-    <T as Trait>::Price,
-    <T as frame_system::Trait>::BlockNumber,
->;
-
-pub type HandicapInfo<T> = Handicap<<T as Trait>::Price>;
 
 decl_storage! {
     trait Store for Module<T: Trait> as XSpot {

--- a/xpallets/dex/spot/src/weight_info.rs
+++ b/xpallets/dex/spot/src/weight_info.rs
@@ -1,0 +1,35 @@
+use frame_support::weights::Weight;
+
+pub trait WeightInfo {
+    fn put_order() -> Weight;
+    fn cancel_order() -> Weight;
+    fn force_cancel_order() -> Weight;
+    fn set_handicap() -> Weight;
+    fn set_price_fluctuation() -> Weight;
+    fn add_trading_pair() -> Weight;
+    fn update_trading_pair() -> Weight;
+}
+
+impl WeightInfo for () {
+    fn put_order() -> Weight {
+        1_000_000_000
+    }
+    fn cancel_order() -> Weight {
+        1_000_000_000
+    }
+    fn force_cancel_order() -> Weight {
+        1_000_000_000
+    }
+    fn set_handicap() -> Weight {
+        1_000_000_000
+    }
+    fn set_price_fluctuation() -> Weight {
+        1_000_000_000
+    }
+    fn add_trading_pair() -> Weight {
+        1_000_000_000
+    }
+    fn update_trading_pair() -> Weight {
+        1_000_000_000
+    }
+}

--- a/xpallets/mining/asset/src/lib.rs
+++ b/xpallets/mining/asset/src/lib.rs
@@ -5,6 +5,7 @@
 mod impls;
 mod rpc;
 mod types;
+mod weight_info;
 
 #[cfg(any(feature = "runtime-benchmarks", test))]
 mod benchmarking;
@@ -19,7 +20,6 @@ use frame_support::{
     ensure,
     storage::IterableStorageMap,
     traits::{Currency, ExistenceRequirement},
-    weights::Weight,
 };
 use frame_system::{ensure_root, ensure_signed};
 use sp_runtime::traits::{SaturatedConversion, Zero};
@@ -36,32 +36,11 @@ use xpallet_support::{traits::TreasuryAccount, warn};
 pub use impls::SimpleAssetRewardPotAccountDeterminer;
 pub use rpc::*;
 pub use types::*;
+pub use weight_info::WeightInfo;
 
 pub type BalanceOf<T> = <<T as xpallet_assets::Trait>::Currency as Currency<
     <T as frame_system::Trait>::AccountId,
 >>::Balance;
-
-pub trait WeightInfo {
-    fn claim() -> Weight;
-    fn set_claim_staking_requirement() -> Weight;
-    fn set_claim_frequency_limit() -> Weight;
-    fn set_asset_power() -> Weight;
-}
-
-impl WeightInfo for () {
-    fn claim() -> Weight {
-        1_000_000_000
-    }
-    fn set_claim_staking_requirement() -> Weight {
-        1_000_000_000
-    }
-    fn set_claim_frequency_limit() -> Weight {
-        1_000_000_000
-    }
-    fn set_asset_power() -> Weight {
-        1_000_000_000
-    }
-}
 
 pub trait Trait: xpallet_assets::Trait {
     /// The overarching event type.

--- a/xpallets/mining/asset/src/weight_info.rs
+++ b/xpallets/mining/asset/src/weight_info.rs
@@ -1,0 +1,23 @@
+use frame_support::weights::Weight;
+
+pub trait WeightInfo {
+    fn claim() -> Weight;
+    fn set_claim_staking_requirement() -> Weight;
+    fn set_claim_frequency_limit() -> Weight;
+    fn set_asset_power() -> Weight;
+}
+
+impl WeightInfo for () {
+    fn claim() -> Weight {
+        1_000_000_000
+    }
+    fn set_claim_staking_requirement() -> Weight {
+        1_000_000_000
+    }
+    fn set_claim_frequency_limit() -> Weight {
+        1_000_000_000
+    }
+    fn set_asset_power() -> Weight {
+        1_000_000_000
+    }
+}

--- a/xpallets/mining/staking/src/lib.rs
+++ b/xpallets/mining/staking/src/lib.rs
@@ -9,6 +9,7 @@ mod reward;
 mod rpc;
 mod slashing;
 mod types;
+mod weight_info;
 
 #[cfg(any(feature = "runtime-benchmarks", test))]
 mod benchmarking;
@@ -21,7 +22,6 @@ use frame_support::{
     decl_error, decl_event, decl_module, decl_storage, ensure,
     storage::IterableStorageMap,
     traits::{Currency, ExistenceRequirement, Get, LockableCurrency, WithdrawReasons},
-    weights::Weight,
 };
 use frame_system::{ensure_root, ensure_signed};
 use sp_runtime::{
@@ -42,66 +42,13 @@ use xpallet_support::{debug, traits::TreasuryAccount};
 pub use impls::{IdentificationTuple, SimpleValidatorRewardPotAccountDeterminer};
 pub use rpc::*;
 pub use types::*;
+pub use weight_info::WeightInfo;
 
 pub type BalanceOf<T> =
     <<T as Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::Balance;
 
 /// Counter for the number of eras that have passed.
 pub type EraIndex = u32;
-
-pub trait WeightInfo {
-    fn register() -> Weight;
-    fn bond() -> Weight;
-    fn unbond() -> Weight;
-    fn unlock_unbonded_withdrawal() -> Weight;
-    fn rebond() -> Weight;
-    fn claim() -> Weight;
-    fn chill() -> Weight;
-    fn validate() -> Weight;
-    fn set_validator_count() -> Weight;
-    fn set_minimum_validator_count() -> Weight;
-    fn set_bonding_duration() -> Weight;
-    fn set_validator_bonding_duration() -> Weight;
-}
-
-impl WeightInfo for () {
-    fn register() -> Weight {
-        1_000_000_000
-    }
-    fn bond() -> Weight {
-        1_000_000_000
-    }
-    fn unbond() -> Weight {
-        1_000_000_000
-    }
-    fn unlock_unbonded_withdrawal() -> Weight {
-        1_000_000_000
-    }
-    fn rebond() -> Weight {
-        1_000_000_000
-    }
-    fn claim() -> Weight {
-        1_000_000_000
-    }
-    fn chill() -> Weight {
-        1_000_000_000
-    }
-    fn validate() -> Weight {
-        1_000_000_000
-    }
-    fn set_validator_count() -> Weight {
-        1_000_000_000
-    }
-    fn set_minimum_validator_count() -> Weight {
-        1_000_000_000
-    }
-    fn set_bonding_duration() -> Weight {
-        1_000_000_000
-    }
-    fn set_validator_bonding_duration() -> Weight {
-        1_000_000_000
-    }
-}
 
 pub trait Trait: frame_system::Trait {
     /// The overarching event type.

--- a/xpallets/mining/staking/src/weight_info.rs
+++ b/xpallets/mining/staking/src/weight_info.rs
@@ -1,0 +1,55 @@
+use frame_support::weights::Weight;
+
+pub trait WeightInfo {
+    fn register() -> Weight;
+    fn bond() -> Weight;
+    fn unbond() -> Weight;
+    fn unlock_unbonded_withdrawal() -> Weight;
+    fn rebond() -> Weight;
+    fn claim() -> Weight;
+    fn chill() -> Weight;
+    fn validate() -> Weight;
+    fn set_validator_count() -> Weight;
+    fn set_minimum_validator_count() -> Weight;
+    fn set_bonding_duration() -> Weight;
+    fn set_validator_bonding_duration() -> Weight;
+}
+
+impl WeightInfo for () {
+    fn register() -> Weight {
+        1_000_000_000
+    }
+    fn bond() -> Weight {
+        1_000_000_000
+    }
+    fn unbond() -> Weight {
+        1_000_000_000
+    }
+    fn unlock_unbonded_withdrawal() -> Weight {
+        1_000_000_000
+    }
+    fn rebond() -> Weight {
+        1_000_000_000
+    }
+    fn claim() -> Weight {
+        1_000_000_000
+    }
+    fn chill() -> Weight {
+        1_000_000_000
+    }
+    fn validate() -> Weight {
+        1_000_000_000
+    }
+    fn set_validator_count() -> Weight {
+        1_000_000_000
+    }
+    fn set_minimum_validator_count() -> Weight {
+        1_000_000_000
+    }
+    fn set_bonding_duration() -> Weight {
+        1_000_000_000
+    }
+    fn set_validator_bonding_duration() -> Weight {
+        1_000_000_000
+    }
+}


### PR DESCRIPTION
- Add `reserved_balance` in `orders()`.
- Remove a duplicated event `UpdateOrder` at the last of `put_order()`.
- Replace `UpdateOrder` with `UpdateMakerOrder`, `UpdateTakerOrder`, `UpdateCanceledOrder`, making it more descriptive.
- Rename `PutOrder` to `NewOrder`.