### PR TITLE
Impl fee split logic

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -407,14 +407,11 @@ impl OnUnbalanced<NegativeImbalance> for DealWithFees {
         let reward_pot = <xpallet_mining_staking::Module<Runtime>>::reward_pot_for(&author);
 
         <pallet_balances::Module<Runtime>>::resolve_creating(&author, to_author);
-        <frame_system::Module<Runtime>>::deposit_event(xpallet_system::RawEvent::AuthorFeePaid(
-            author,
-            to_author_numeric_amount,
-        ));
-
         <pallet_balances::Module<Runtime>>::resolve_creating(&reward_pot, to_reward_pot);
         <frame_system::Module<Runtime>>::deposit_event(
-            xpallet_system::RawEvent::AuthorRewardPotFeePaid(
+            xpallet_system::RawEvent::TransactionFeePaid(
+                author,
+                to_author_numeric_amount,
                 reward_pot,
                 to_reward_pot_numeric_amount,
             ),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -59,8 +59,8 @@ pub use sp_runtime::BuildStorage;
 pub use frame_support::{
     construct_runtime, debug, parameter_types,
     traits::{
-        Currency, Filter, InstanceFilter, KeyOwnerProofSystem, LockIdentifier, OnUnbalanced,
-        Randomness,
+        Currency, Filter, Imbalance, InstanceFilter, KeyOwnerProofSystem, LockIdentifier,
+        OnUnbalanced, Randomness,
     },
     weights::{
         constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
@@ -397,16 +397,33 @@ type NegativeImbalance = <Balances as Currency<AccountId>>::NegativeImbalance;
 pub struct DealWithFees;
 impl OnUnbalanced<NegativeImbalance> for DealWithFees {
     fn on_unbalanceds<B>(mut fees_then_tips: impl Iterator<Item = NegativeImbalance>) {
-        if let Some(_fees) = fees_then_tips.next() {
-            // for fees, 80% to treasury, 20% to author
-            // let mut split = fees.ration(80, 20);
-            // if let Some(tips) = fees_then_tips.next() {
-            //     // for tips, if any, 80% to treasury, 20% to author (though this can be anything)
-            //     tips.ration_merge_into(80, 20, &mut split);
-            // }
-            // Treasury::on_unbalanced(split.0);
-            // Author::on_unbalanced(split.1);
-            // TODO impl fees dispatch
+        if let Some(fees) = fees_then_tips.next() {
+            // for fees, 90% to the reward pot of author, 10% to author
+            let mut split = fees.ration(90, 10);
+            if let Some(tips) = fees_then_tips.next() {
+                // for tips, if any, 90% to the reward pot of author, 10% to author (though this can be anything)
+                tips.ration_merge_into(90, 10, &mut split);
+            }
+
+            let (to_reward_pot, to_author) = split;
+
+            let to_author_numeric_amount = to_author.peek();
+            let to_reward_pot_numeric_amount = to_reward_pot.peek();
+
+            let author = <pallet_authorship::Module<Runtime>>::author();
+            let reward_pot = <xpallet_mining_staking::Module<Runtime>>::reward_pot_for(&author);
+
+            <pallet_balances::Module<Runtime>>::resolve_creating(&author, to_author);
+            <frame_system::Module<Runtime>>::deposit_event(pallet_balances::RawEvent::Deposit(
+                author,
+                to_author_numeric_amount,
+            ));
+
+            <pallet_balances::Module<Runtime>>::resolve_creating(&reward_pot, to_reward_pot);
+            <frame_system::Module<Runtime>>::deposit_event(pallet_balances::RawEvent::Deposit(
+                reward_pot,
+                to_reward_pot_numeric_amount,
+            ));
         }
     }
 }

--- a/xpallets/system/src/lib.rs
+++ b/xpallets/system/src/lib.rs
@@ -6,14 +6,21 @@ use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 use frame_support::{
     decl_error, decl_event, decl_module, decl_storage,
     dispatch::{CallMetadata, DispatchResult},
+    traits::{Currency, LockableCurrency},
 };
 use frame_system::ensure_root;
 
 use xpallet_protocol::NetworkType;
 
+pub type BalanceOf<T> =
+    <<T as Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::Balance;
+
 pub trait Trait: frame_system::Trait {
     /// Event
     type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
+
+    /// The currency mechanism.
+    type Currency: LockableCurrency<Self::AccountId, Moment = Self::BlockNumber>;
 }
 
 decl_error! {
@@ -25,10 +32,15 @@ decl_error! {
 
 decl_event!(
     pub enum Event<T> where
+        Balance = BalanceOf<T>,
         <T as frame_system::Trait>::AccountId
     {
         BlockAccount(AccountId),
         RevokeBlockedAccounts(AccountId),
+        /// Transaction fee is paid to the block author. [author, amount]
+        AuthorFeePaid(AccountId, Balance),
+        /// Transaction fee is paid to the reward pot of block author. [reward_pot, amount]
+        AuthorRewardPotFeePaid(AccountId, Balance),
     }
 );
 

--- a/xpallets/system/src/lib.rs
+++ b/xpallets/system/src/lib.rs
@@ -37,10 +37,9 @@ decl_event!(
     {
         BlockAccount(AccountId),
         RevokeBlockedAccounts(AccountId),
-        /// Transaction fee is paid to the block author. [author, amount]
-        AuthorFeePaid(AccountId, Balance),
-        /// Transaction fee is paid to the reward pot of block author. [reward_pot, amount]
-        AuthorRewardPotFeePaid(AccountId, Balance),
+        /// Transaction fee is paid to the block author and its reward pot accordingly.
+        /// [author, author_fee, reward_pot, reward_pot_fee]
+        TransactionFeePaid(AccountId, Balance, AccountId, Balance),
     }
 );
 

--- a/xpallets/system/src/lib.rs
+++ b/xpallets/system/src/lib.rs
@@ -6,11 +6,14 @@ use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 use frame_support::{
     decl_error, decl_event, decl_module, decl_storage,
     dispatch::{CallMetadata, DispatchResult},
-    traits::{Currency, LockableCurrency},
+    traits::Currency,
 };
 use frame_system::ensure_root;
 
 use xpallet_protocol::NetworkType;
+
+const PALLET_MARK: &[u8; 1] = b"#";
+const ALWAYS_ALLOW: [&str; 1] = ["Sudo"];
 
 pub type BalanceOf<T> =
     <<T as Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::Balance;
@@ -20,7 +23,7 @@ pub trait Trait: frame_system::Trait {
     type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
 
     /// The currency mechanism.
-    type Currency: LockableCurrency<Self::AccountId, Moment = Self::BlockNumber>;
+    type Currency: Currency<Self::AccountId>;
 }
 
 decl_error! {
@@ -59,12 +62,10 @@ decl_module! {
                 } else {
                     sub_paused.insert(PALLET_MARK.to_vec(), ());
                 }
+            } else if let Some(c) = call {
+                sub_paused.remove(&c[..]);
             } else {
-                if let Some(c) = call {
-                    sub_paused.remove(&c[..]);
-                } else {
-                    sub_paused.remove(&PALLET_MARK[..]);
-                }
+                sub_paused.remove(&PALLET_MARK[..]);
             }
 
             if sub_paused.is_empty() {
@@ -100,9 +101,6 @@ decl_storage! {
         pub BlockedAccounts get(fn blocked_accounts): map hasher(blake2_128_concat) T::AccountId => Option<()>;
     }
 }
-
-const ALWAYS_ALLOW: [&str; 1] = ["Sudo"];
-const PALLET_MARK: &[u8; 1] = b"#";
 
 impl<T: Trait> Module<T> {
     pub fn is_paused(metadata: CallMetadata) -> bool {

--- a/xpallets/system/src/lib.rs
+++ b/xpallets/system/src/lib.rs
@@ -37,7 +37,7 @@ decl_event!(
     {
         BlockAccount(AccountId),
         RevokeBlockedAccounts(AccountId),
-        /// Transaction fee is paid to the block author and its reward pot accordingly.
+        /// Transaction fee is paid to the block author and its reward pot in 10:90.
         /// [author, author_fee, reward_pot, reward_pot_fee]
         TransactionFeePaid(AccountId, Balance, AccountId, Balance),
     }


### PR DESCRIPTION
In ChainX 1.0, 90% of fees are distributed to the reward pot of author, and the rest 10% goes to the author directly, apply the same rule for ChainX 2.0