### PR TITLE
Add FullIdentification type

### DIFF
--- a/scripts/chainx-js/chainx_types_manual.json
+++ b/scripts/chainx-js/chainx_types_manual.json
@@ -259,6 +259,7 @@
     },
     "OrderInfo": "Order",
     "HandicapInfo": "Handicap",
+    "FullIdentification": "ValidatorId",
     "Price": "Balance",
     "WithdrawalRecordOf": "WithdrawalRecord",
     "WithdrawalRecordForRpc": {

--- a/scripts/chainx-js/res/chainx_types.json
+++ b/scripts/chainx-js/res/chainx_types.json
@@ -17,17 +17,6 @@
             "Polkadot"
         ]
     },
-    "XRC20Selector": {
-        "_enum": [
-            "BalanceOf",
-            "TotalSupply",
-            "Name",
-            "Symbol",
-            "Decimals",
-            "Issue",
-            "Destroy"
-        ]
-    },
     "OrderType": {
         "_enum": [
             "Limit",
@@ -54,11 +43,11 @@
     },
     "Memo": "Text",
     "AssetInfo": {
-        "token": "Token",
-        "tokenName": "Token",
+        "token": "String",
+        "tokenName": "String",
         "chain": "Chain",
         "decimals": "Decimals",
-        "desc": "Desc"
+        "desc": "String"
     },
     "TradingPairProfile": {
         "id": "TradingPairId",
@@ -165,7 +154,6 @@
     "Desc": "Text",
     "Token": "Text",
     "AddrStr": "Text",
-    "Selector": "[u8; 4]",
     "HandicapInfo": "Handicap",
     "Price": "Balance",
     "OrderId": "u64",
@@ -410,6 +398,7 @@
     "String": "Text",
     "Balance": "u128",
     "MiningPower": "u128",
+    "FullIdentification": "ValidatorId",
     "WithdrawalRecordOf": "WithdrawalRecord",
     "WithdrawalRecordForRpc": {
         "assetId": "AssetId",


### PR DESCRIPTION
ChainX 2.0 uses a different type of `IdentificationTuple` which is used in the event of `im-online`, have to specify `FullIdentitication` as `ValidatorId` in ChainX, otherwise JS fails to decode the event data.

https://github.com/chainx-org/ChainX/blob/96d408b59b02a98909b4cf00335d3a414a4f351f/xpallets/mining/staking/src/impls.rs#L365-L373

https://github.com/paritytech/substrate/blob/a200cdb93c6af5763b9c7bf313fa708764ac88ca/frame/im-online/src/lib.rs#L277