### PR TITLE
Fix executable name

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "chainx-cli"
 version = "2.0.0-alpha.1"
 authors = ["The ChainX Authors"]
-description = "ChainX Client Node"
+description = "Implementation of protocol https://chainx.org in Rust based on the Substrate framework."
 edition = "2018"
 
 [dependencies]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "chainx-cli"
 version = "2.0.0-alpha.1"
 authors = ["The ChainX Authors"]
+description = "ChainX Client Node"
 edition = "2018"
 
 [dependencies]

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -29,7 +29,7 @@ impl SubstrateCli for Cli {
     }
 
     fn support_url() -> String {
-        "https://github.com/chainx-org/ChainX/issue/new".into()
+        "https://github.com/chainx-org/ChainX/issues/new".into()
     }
 
     fn copyright_start_year() -> i32 {

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -17,7 +17,7 @@ impl SubstrateCli for Cli {
     }
 
     fn executable_name() -> String {
-        env!("CARGO_PKG_NAME").into()
+        "chainx".into()
     }
 
     fn description() -> String {
@@ -29,11 +29,11 @@ impl SubstrateCli for Cli {
     }
 
     fn support_url() -> String {
-        "https://github.com/chainx-org/ChainX".into()
+        "https://github.com/chainx-org/ChainX/issue/new".into()
     }
 
     fn copyright_start_year() -> i32 {
-        2020
+        2019
     }
 
     fn load_spec(&self, id: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

before:

```
chainx-cli 2.0.0-alpha.1-38a21db3-x86_64-linux-gnu
```

after:

```
chainx 2.0.0-alpha.1-38a21db3-x86_64-linux-gnu
```