### PR TITLE
Fix u128 RPC serialization/deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8936,6 +8936,7 @@ dependencies = [
  "sp-blockchain",
  "sp-runtime",
  "xpallet-assets-rpc-runtime-api",
+ "xpallet-support",
 ]
 
 [[package]]
@@ -8985,6 +8986,7 @@ dependencies = [
  "sp-blockchain",
  "sp-runtime",
  "xpallet-dex-spot-rpc-runtime-api",
+ "xpallet-support",
 ]
 
 [[package]]
@@ -9071,6 +9073,7 @@ dependencies = [
  "sp-blockchain",
  "sp-runtime",
  "xpallet-gateway-common-rpc-runtime-api",
+ "xpallet-support",
 ]
 
 [[package]]
@@ -9198,6 +9201,7 @@ dependencies = [
  "sp-blockchain",
  "sp-runtime",
  "xpallet-mining-asset-rpc-runtime-api",
+ "xpallet-support",
 ]
 
 [[package]]
@@ -9251,6 +9255,7 @@ dependencies = [
  "sp-blockchain",
  "sp-runtime",
  "xpallet-mining-staking-rpc-runtime-api",
+ "xpallet-support",
 ]
 
 [[package]]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -24,14 +24,14 @@ xpallet-support = { path = "../xpallets/support", default-features = false }
 default = ["std"]
 std = [
     "codec/std",
-    "serde/std",
-
+    "serde",
+    # Substrate primitives
     "sp-application-crypto/std",
     "sp-core/std",
     "sp-runtime/std",
     "sp-std/std",
-
+    # Substrate pallets
     "frame-system/std",
-
+    # ChainX pallets
     "xpallet-support/std",
 ]

--- a/primitives/assets-registrar/Cargo.toml
+++ b/primitives/assets-registrar/Cargo.toml
@@ -7,13 +7,17 @@ edition = "2018"
 [dependencies]
 impl-trait-for-tuples = "0.1.3"
 
+# Substrate pallets
 frame-support = { version = "2.0.0", default-features = false }
 
+# ChainX primitives
 chainx-primitives = { path = "../../primitives", default-features = false }
 
 [features]
 default = ["std"]
 std = [
+    # Substrate pallets
     "frame-support/std",
+    # ChainX primitives
     "chainx-primitives/std",
 ]

--- a/primitives/genesis-builder/Cargo.toml
+++ b/primitives/genesis-builder/Cargo.toml
@@ -16,7 +16,7 @@ xpallet-support = { path = "../../xpallets/support", default-features = false }
 [features]
 default = ["std"]
 std = [
-    "serde/std",
+    "serde",
     # ChainX primitives
     "chainx-primitives/std",
     # ChainX pallets

--- a/primitives/genesis-builder/src/lib.rs
+++ b/primitives/genesis-builder/src/lib.rs
@@ -12,14 +12,6 @@ mod genesis_params {
     use chainx_primitives::Balance;
     use serde::{Deserialize, Serialize};
 
-    fn deserialize_u128<'de, D>(deserializer: D) -> Result<u128, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        s.parse::<u128>().map_err(serde::de::Error::custom)
-    }
-
     #[derive(Debug, Default, Clone, Serialize, Deserialize)]
     pub struct AllParams<AccountId, TBalance, AssetBalanceOf, StakingBalanceOf> {
         pub balances: BalancesParams<AccountId, TBalance>,
@@ -54,7 +46,7 @@ mod genesis_params {
         pub referral_id: Vec<u8>,
         pub self_bonded: Balance,
         pub total_nomination: Balance,
-        #[serde(deserialize_with = "deserialize_u128")]
+        #[serde(with = "xpallet_support::serde_num_str")]
         pub total_weight: u128,
     }
 
@@ -62,7 +54,7 @@ mod genesis_params {
     pub struct Nomination<AccountId, Balance> {
         pub nominee: AccountId,
         pub nomination: Balance,
-        #[serde(deserialize_with = "deserialize_u128")]
+        #[serde(with = "xpallet_support::serde_num_str")]
         pub weight: u128,
     }
 
@@ -81,14 +73,14 @@ mod genesis_params {
     #[derive(Debug, Default, Clone, Serialize, Deserialize)]
     pub struct XBtcInfo {
         pub balance: Balance,
-        #[serde(deserialize_with = "deserialize_u128")]
+        #[serde(with = "xpallet_support::serde_num_str")]
         pub weight: u128,
     }
 
     #[derive(Debug, Default, Clone, Serialize, Deserialize)]
     pub struct XBtcMiner<AccountId> {
         pub who: AccountId,
-        #[serde(deserialize_with = "deserialize_u128")]
+        #[serde(with = "xpallet_support::serde_num_str")]
         pub weight: u128,
     }
 

--- a/primitives/io/Cargo.toml
+++ b/primitives/io/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.4", default-features = false }
 
+# Substrate primitives
 sp-core = { version = "2.0.0", default-features = false }
 sp-runtime = { version = "2.0.0", default-features = false }
 sp-runtime-interface = { version = "2.0.0", default-features = false }
@@ -18,7 +19,7 @@ hex = "0.4"
 default = ["std"]
 std = [
     "codec/std",
-
+    # Substrate primitives
     "sp-core/std",
     "sp-runtime/std",
     "sp-runtime-interface/std",

--- a/primitives/mining/common/Cargo.toml
+++ b/primitives/mining/common/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2018"
 
 [dependencies]
 # Substrate primitives
-sp-std = { version = "2.0.0", default-features = false }
-sp-runtime = { version = "2.0.0", default-features = false }
 sp-arithmetic = { version = "2.0.0", default-features = false }
+sp-runtime = { version = "2.0.0", default-features = false }
+sp-std = { version = "2.0.0", default-features = false }
 
 # ChainX primitives
 chainx-primitives = { path = "../../../primitives", default-features = false }
@@ -16,8 +16,10 @@ chainx-primitives = { path = "../../../primitives", default-features = false }
 [features]
 default = ["std"]
 std = [
-    "sp-std/std",
+    # Substrate primitives
+    "sp-arithmetic/std",
     "sp-runtime/std",
-
+    "sp-std/std",
+    # ChainX primitives
     "chainx-primitives/std",
 ]

--- a/primitives/mining/common/src/lib.rs
+++ b/primitives/mining/common/src/lib.rs
@@ -47,7 +47,7 @@ use sp_std::result::Result;
 pub type WeightType = u128;
 
 /// The getter and setter methods for the further mining weight processing.
-pub trait BaseMiningWeightHandle<Balance, BlockNumber> {
+pub trait BaseMiningWeight<Balance, BlockNumber> {
     fn amount(&self) -> Balance;
     /// Set the new amount.
     ///
@@ -86,8 +86,8 @@ impl<Balance: BaseArithmetic> Delta<Balance> {
 }
 
 /// General logic for state changes of the mining weight operations.
-pub trait MiningWeightHandle<Balance: BaseArithmetic + Copy, BlockNumber>:
-    BaseMiningWeightHandle<Balance, BlockNumber>
+pub trait MiningWeight<Balance: BaseArithmetic + Copy, BlockNumber>:
+    BaseMiningWeight<Balance, BlockNumber>
 {
     /// Set the new amount after settling the change of nomination.
     fn settle_and_set_amount(&mut self, delta: &Delta<Balance>) {
@@ -119,11 +119,8 @@ pub trait MiningWeightHandle<Balance: BaseArithmetic + Copy, BlockNumber>:
     }
 }
 
-impl<
-        Balance: BaseArithmetic + Copy,
-        BlockNumber,
-        T: BaseMiningWeightHandle<Balance, BlockNumber>,
-    > MiningWeightHandle<Balance, BlockNumber> for T
+impl<Balance: BaseArithmetic + Copy, BlockNumber, T: BaseMiningWeight<Balance, BlockNumber>>
+    MiningWeight<Balance, BlockNumber> for T
 {
 }
 
@@ -205,7 +202,7 @@ pub type WeightFactors = (WeightType, u128, u128);
 pub fn generic_weight_factors<
     Balance: BaseArithmetic,
     BlockNumber: BaseArithmetic,
-    W: BaseMiningWeightHandle<Balance, BlockNumber>,
+    W: BaseMiningWeight<Balance, BlockNumber>,
 >(
     w: W,
     current_block: BlockNumber,

--- a/primitives/mining/common/src/lib.rs
+++ b/primitives/mining/common/src/lib.rs
@@ -47,7 +47,7 @@ use sp_std::result::Result;
 pub type WeightType = u128;
 
 /// The getter and setter methods for the further mining weight processing.
-pub trait BaseMiningWeight<Balance, BlockNumber> {
+pub trait BaseMiningWeightHandle<Balance, BlockNumber> {
     fn amount(&self) -> Balance;
     /// Set the new amount.
     ///
@@ -86,8 +86,8 @@ impl<Balance: BaseArithmetic> Delta<Balance> {
 }
 
 /// General logic for state changes of the mining weight operations.
-pub trait MiningWeight<Balance: BaseArithmetic + Copy, BlockNumber>:
-    BaseMiningWeight<Balance, BlockNumber>
+pub trait MiningWeightHandle<Balance: BaseArithmetic + Copy, BlockNumber>:
+    BaseMiningWeightHandle<Balance, BlockNumber>
 {
     /// Set the new amount after settling the change of nomination.
     fn settle_and_set_amount(&mut self, delta: &Delta<Balance>) {
@@ -119,8 +119,11 @@ pub trait MiningWeight<Balance: BaseArithmetic + Copy, BlockNumber>:
     }
 }
 
-impl<Balance: BaseArithmetic + Copy, BlockNumber, T: BaseMiningWeight<Balance, BlockNumber>>
-    MiningWeight<Balance, BlockNumber> for T
+impl<
+        Balance: BaseArithmetic + Copy,
+        BlockNumber,
+        T: BaseMiningWeightHandle<Balance, BlockNumber>,
+    > MiningWeightHandle<Balance, BlockNumber> for T
 {
 }
 
@@ -202,7 +205,7 @@ pub type WeightFactors = (WeightType, u128, u128);
 pub fn generic_weight_factors<
     Balance: BaseArithmetic,
     BlockNumber: BaseArithmetic,
-    W: BaseMiningWeight<Balance, BlockNumber>,
+    W: BaseMiningWeightHandle<Balance, BlockNumber>,
 >(
     w: W,
     current_block: BlockNumber,

--- a/primitives/mining/staking/Cargo.toml
+++ b/primitives/mining/staking/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2018"
 
 [dependencies]
 # Substrate primitives
-sp-std = { version = "2.0.0", default-features = false }
 sp-runtime = { version = "2.0.0", default-features = false }
+sp-std = { version = "2.0.0", default-features = false }
 
 # ChainX primitives
 chainx-primitives = { path = "../../../primitives", default-features = false }
@@ -16,9 +16,10 @@ xp-mining-common = { path = "../common", default-features = false }
 [features]
 default = ["std"]
 std = [
-    "sp-std/std",
+    # Substrate primitives
     "sp-runtime/std",
-
+    "sp-std/std",
+    # ChainX primitives
     "chainx-primitives/std",
     "xp-mining-common/std",
 ]

--- a/primitives/protocol/Cargo.toml
+++ b/primitives/protocol/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.4", features = ["derive"], default-features = false }
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 # Substrate primitives
 sp-runtime = { version = "2.0.0", default-features = false }

--- a/primitives/runtime/Cargo.toml
+++ b/primitives/runtime/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 codec = { package = "parity-scale-codec", version = "1.3.4", default-features = false }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 
+# Substrate primitives
 sp-core = { version = "2.0.0", default-features = false }
 sp-runtime = { version = "2.0.0", default-features = false }
 sp-std = { version = "2.0.0", default-features = false }
@@ -20,7 +21,7 @@ default = ["std"]
 std = [
     "codec/std",
     "serde/std",
-
+    # Substrate primitives
     "sp-core/std",
     "sp-runtime/std",
     "sp-std/std",

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.4", features = ["derive"] }
-jsonrpc-core = { version = "15.0.0", features = ["arbitrary_precision"] }
+jsonrpc-core = "15.0.0"
 jsonrpc-pubsub = "15.0.0"
 
 # Substrate client

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -21,6 +21,9 @@ use sp_transaction_pool::TransactionPool;
 use chainx_primitives::Block;
 use chainx_runtime::{AccountId, Balance, BlockNumber, Hash, Index};
 
+use xpallet_mining_asset_rpc_runtime_api::MiningWeight;
+use xpallet_mining_staking_rpc_runtime_api::VoteWeight;
+
 /// Light client extra dependencies.
 pub struct LightDeps<C, F, P> {
     /// The client instance to use.
@@ -90,22 +93,28 @@ where
     C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
     C::Api: xpallet_assets_rpc_runtime_api::XAssetsApi<Block, AccountId, Balance>,
     C::Api:
-        xpallet_mining_staking_rpc_runtime_api::XStakingApi<Block, AccountId, Balance, BlockNumber>,
-    C::Api:
         xpallet_dex_spot_rpc_runtime_api::XSpotApi<Block, AccountId, Balance, BlockNumber, Balance>,
-    C::Api: xpallet_mining_asset_rpc_runtime_api::XMiningAssetApi<
-        Block,
-        AccountId,
-        Balance,
-        BlockNumber,
-    >,
+    C::Api: xpallet_gateway_common_rpc_runtime_api::XGatewayCommonApi<Block, AccountId, Balance>,
     C::Api: xpallet_gateway_records_rpc_runtime_api::XGatewayRecordsApi<
         Block,
         AccountId,
         Balance,
         BlockNumber,
     >,
-    C::Api: xpallet_gateway_common_rpc_runtime_api::XGatewayCommonApi<Block, AccountId, Balance>,
+    C::Api: xpallet_mining_staking_rpc_runtime_api::XStakingApi<
+        Block,
+        AccountId,
+        Balance,
+        VoteWeight,
+        BlockNumber,
+    >,
+    C::Api: xpallet_mining_asset_rpc_runtime_api::XMiningAssetApi<
+        Block,
+        AccountId,
+        Balance,
+        MiningWeight,
+        BlockNumber,
+    >,
     <C::Api as sp_api::ApiErrorExt>::Error: fmt::Debug,
     P: TransactionPool + 'static,
     SC: SelectChain<Block> + 'static,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -88,6 +88,8 @@ pub use xpallet_gateway_common::{
     types::{GenericTrusteeIntentionProps, GenericTrusteeSessionInfo, TrusteeInfoConfig},
 };
 pub use xpallet_gateway_records::Withdrawal;
+pub use xpallet_mining_asset::MiningWeight;
+pub use xpallet_mining_staking::VoteWeight;
 
 /// Constant values used within the runtime.
 pub mod constants;
@@ -1224,17 +1226,17 @@ impl_runtime_apis! {
         }
     }
 
-    impl xpallet_mining_staking_rpc_runtime_api::XStakingApi<Block, AccountId, Balance, BlockNumber> for Runtime {
-        fn validators() -> Vec<ValidatorInfo<AccountId, Balance, BlockNumber>> {
+    impl xpallet_mining_staking_rpc_runtime_api::XStakingApi<Block, AccountId, Balance, VoteWeight, BlockNumber> for Runtime {
+        fn validators() -> Vec<ValidatorInfo<AccountId, Balance, VoteWeight, BlockNumber>> {
             XStaking::validators_info()
         }
-        fn validator_info_of(who: AccountId) -> ValidatorInfo<AccountId, Balance, BlockNumber> {
+        fn validator_info_of(who: AccountId) -> ValidatorInfo<AccountId, Balance, VoteWeight, BlockNumber> {
             XStaking::validator_info_of(who)
         }
         fn staking_dividend_of(who: AccountId) -> BTreeMap<AccountId, Balance> {
             XStaking::staking_dividend_of(who)
         }
-        fn nomination_details_of(who: AccountId) -> BTreeMap<AccountId, NominatorLedger<Balance, BlockNumber>> {
+        fn nomination_details_of(who: AccountId) -> BTreeMap<AccountId, NominatorLedger<Balance, VoteWeight, BlockNumber>> {
             XStaking::nomination_details_of(who)
         }
         fn nominator_info_of(who: AccountId) -> NominatorInfo<BlockNumber> {
@@ -1256,8 +1258,8 @@ impl_runtime_apis! {
         }
     }
 
-    impl xpallet_mining_asset_rpc_runtime_api::XMiningAssetApi<Block, AccountId, Balance, BlockNumber> for Runtime {
-        fn mining_assets() -> Vec<MiningAssetInfo<AccountId, Balance, BlockNumber>> {
+    impl xpallet_mining_asset_rpc_runtime_api::XMiningAssetApi<Block, AccountId, Balance, MiningWeight, BlockNumber> for Runtime {
+        fn mining_assets() -> Vec<MiningAssetInfo<AccountId, Balance, MiningWeight, BlockNumber>> {
             XMiningAsset::mining_assets()
         }
 
@@ -1265,7 +1267,7 @@ impl_runtime_apis! {
             XMiningAsset::mining_dividend(who)
         }
 
-        fn miner_ledger(who: AccountId) -> BTreeMap<AssetId, MinerLedger<BlockNumber>> {
+        fn miner_ledger(who: AccountId) -> BTreeMap<AssetId, MinerLedger<MiningWeight, BlockNumber>> {
             XMiningAsset::miner_ledger(who)
         }
     }

--- a/scripts/chainx-js/chainx_types_manual.json
+++ b/scripts/chainx-js/chainx_types_manual.json
@@ -239,14 +239,14 @@
         "data": "Vec<RpcOrder>"
     },
     "String": "Text",
-    "Price": "String",
-    "Balance": "String",
-    "MiningWeight": "String",
-    "VoteWeight": "String",
-    "RpcPrice": "Price",
-    "RpcBalance": "Balance",
-    "RpcMiningWeight": "MiningWeight",
-    "RpcVoteWeight": "VoteWeight",
+    "Price": "u128",
+    "Balance": "u128",
+    "MiningWeight": "u128",
+    "VoteWeight": "u128",
+    "RpcPrice": "String",
+    "RpcBalance": "String",
+    "RpcMiningWeight": "String",
+    "RpcVoteWeight": "String",
     "AssetRestrictions":  {
         "bits": "u32"
     },

--- a/scripts/chainx-js/chainx_types_manual.json
+++ b/scripts/chainx-js/chainx_types_manual.json
@@ -190,7 +190,7 @@
         "is_chilled": "bool",
         "last_chilled": "Option<BlockNumber>",
         "total": "Balance",
-        "last_total_vote_weight": "WeightType",
+        "last_total_vote_weight": "VoteWeight",
         "last_total_vote_weight_update": "BlockNumber",
         "is_validating": "bool",
         "self_bonded": "Balance",
@@ -213,7 +213,7 @@
     },
     "NominatorLedger": {
         "nomination": "Balance",
-        "last_vote_weight": "WeightType",
+        "last_vote_weight": "VoteWeight",
         "last_vote_weight_update": "BlockNumber",
         "unbonded_chunks": "Vec<Unbonded>"
     },
@@ -222,7 +222,7 @@
         "mining_power": "FixedAssetPower",
         "reward_pot": "AccountId",
         "reward_pot_balance": "Balance",
-        "last_total_mining_weight": "WeightType",
+        "last_total_mining_weight": "MiningWeight",
         "last_total_mining_weight_update": "BlockNumber"
     },
     "Unbonded": {
@@ -239,17 +239,20 @@
         "data": "Vec<RpcOrder>"
     },
     "String": "Text",
-    "Balance": "u128",
-    "WeightType": "u128",
-    "MiningPower": "u128",
-    "MiningWeight": "u128",
+    "Price": "String",
+    "Balance": "String",
+    "MiningWeight": "String",
+    "VoteWeight": "String",
+    "RpcPrice": "Price",
+    "RpcBalance": "Balance",
+    "RpcMiningWeight": "MiningWeight",
+    "RpcVoteWeight": "VoteWeight",
     "AssetRestrictions":  {
-        "mask": "u32"
+        "bits": "u32"
     },
     "OrderInfo": "Order",
     "HandicapInfo": "Handicap",
     "FullIdentification": "ValidatorId",
-    "Price": "Balance",
     "WithdrawalRecordOf": "WithdrawalRecord",
     "RpcWithdrawalRecord": {
         "asset_id": "AssetId",

--- a/scripts/chainx-js/res/chainx_rpc.json
+++ b/scripts/chainx-js/res/chainx_rpc.json
@@ -13,7 +13,7 @@
                     "isOptional": true
                 }
             ],
-            "type": "BTreeMap<AssetId, BTreeMap<AssetType, Balance>>"
+            "type": "BTreeMap<AssetId, BTreeMap<AssetType, RpcBalance<Balance>>>"
         },
         "getAssets": {
             "description": "get all assets balance and infos",
@@ -37,7 +37,7 @@
                     "isOptional": true
                 }
             ],
-            "type": "Vec<FullPairInfo<Price, BlockNumber>>"
+            "type": "Vec<FullPairInfo<RpcPrice<Price>, BlockNumber>>"
         },
         "getOrdersByAccount": {
             "description": "Get the orders of an account.",
@@ -60,7 +60,7 @@
                     "isOptional": true
                 }
             ],
-            "type": "Page<Vec<RpcOrder<TradingPairId, AccountId, Balance, Price, BlockNumber>>>"
+            "type": "Page<Vec<RpcOrder<TradingPairId, AccountId, RpcBalance<Balance>, RpcPrice<Price>, BlockNumber>>>"
         },
         "getDepth": {
             "description": "Get the depth of a trading pair.",
@@ -79,7 +79,7 @@
                     "isOptional": true
                 }
             ],
-            "type": "Option<Depth<Price, Balance>>"
+            "type": "Option<Depth<RpcPrice<Price>, RpcBalance<Balance>>>"
         }
     },
     "xgatewaycommon": {
@@ -111,7 +111,7 @@
                     "isOptional": true
                 }
             ],
-            "type": "WithdrawalLimit<Balance>"
+            "type": "WithdrawalLimit<RpcBalance<Balance>>"
         },
         "verifyWithdrawal": {
             "description": "Use the params to verify whether the withdrawal apply is valid. Notice those params is same as the params for call `XGatewayCommon::withdraw(...)`, including checking address is valid or something else. Front-end should use this rpc to check params first, than could create the extrinsic.",
@@ -245,7 +245,7 @@
                     "isOptional": true
                 }
             ],
-            "type": "Vec<MiningAssetInfo<AccountId, Balance, BlockNumber>>"
+            "type": "Vec<MiningAssetInfo<AccountId, RpcBalance<Balance>, RpcMiningWeight<MiningWeight>, BlockNumber>"
         },
         "getDividendByAccount": {
             "description": "Get the asset mining dividends info given the asset miner AccountId.",
@@ -260,7 +260,7 @@
                     "isOptional": true
                 }
             ],
-            "type": "BTreeMap<AssetId, Balance>"
+            "type": "BTreeMap<AssetId, RpcBalance<Balance>>"
         },
         "getMinerLedgerByAccount": {
             "description": "Get the mining ledger details given the asset miner AccountId.",
@@ -275,7 +275,7 @@
                     "isOptional": true
                 }
             ],
-            "type": "BTreeMap<AssetId, MinerLedger<BlockNumber>>"
+            "type": "BTreeMap<AssetId, MinerLedger<RpcMiningWeight<MiningWeight>, BlockNumber>>"
         }
     },
     "xstaking": {
@@ -288,7 +288,7 @@
                     "isOptional": true
                 }
             ],
-            "type": "Vec<ValidatorInfo<AccountId, Balance, BlockNumber>>"
+            "type": "Vec<ValidatorInfo<AccountId, RpcBalance<Balance>, RpcVoteWeight<VoteWeight>, BlockNumber>>"
         },
         "getValidatorByAccount": {
             "description": "Get overall information given the validator AccountId.",
@@ -303,7 +303,7 @@
                     "isOptional": true
                 }
             ],
-            "type": "ValidatorInfo<AccountId, Balance, BlockNumber>"
+            "type": "ValidatorInfo<AccountId, RpcBalance<Balance>, RpcVoteWeight<VoteWeight>, BlockNumber>"
         },
         "getDividendByAccount": {
             "description": "Get the staking dividends info given the staker AccountId.",
@@ -318,7 +318,7 @@
                     "isOptional": true
                 }
             ],
-            "type": "BTreeMap<AccountId, Balance>"
+            "type": "BTreeMap<AccountId, RpcBalance<Balance>>"
         },
         "getNominationByAccount": {
             "description": "Get the nomination details given the staker AccountId.",
@@ -333,7 +333,7 @@
                     "isOptional": true
                 }
             ],
-            "type": "BTreeMap<AccountId, NominatorLedger<Balance, BlockNumber>>"
+            "type": "BTreeMap<AccountId, NominatorLedger<RpcBalance<Balance>, RpcVoteWeight<VoteWeight>, BlockNumber>>"
         },
         "getNominatorByAccount": {
             "description": "Get individual nominator information given the nominator AccountId.",

--- a/scripts/chainx-js/res/chainx_types.json
+++ b/scripts/chainx-js/res/chainx_types.json
@@ -1,4 +1,10 @@
 {
+    "NetworkType": {
+        "_enum": [
+            "Mainnet",
+            "Testnet"
+        ]
+    },
     "AssetType": {
         "_enum": [
             "Usable",
@@ -32,12 +38,6 @@
         "_enum": [
             "Bonded",
             "BondedWithdrawal"
-        ]
-    },
-    "NetworkType": {
-        "_enum": [
-            "Mainnet",
-            "Testnet"
         ]
     },
     "Memo": "Text",
@@ -97,7 +97,7 @@
         "miningPower": "FixedAssetPower",
         "rewardPot": "AccountId",
         "rewardPotBalance": "Balance",
-        "lastTotalMiningWeight": "WeightType",
+        "lastTotalMiningWeight": "MiningWeight",
         "lastTotalMiningWeightUpdate": "BlockNumber"
     },
     "AssetLedger": {
@@ -126,12 +126,12 @@
     },
     "ValidatorLedger": {
         "totalNomination": "Balance",
-        "lastTotalVoteWeight": "WeightType",
+        "lastTotalVoteWeight": "VoteWeight",
         "lastTotalVoteWeightUpdate": "BlockNumber"
     },
     "NominatorLedger": {
         "nomination": "Balance",
-        "lastVoteWeight": "WeightType",
+        "lastVoteWeight": "VoteWeight",
         "lastVoteWeightUpdate": "BlockNumber",
         "unbondedChunks": "Vec<Unbonded>"
     },
@@ -154,7 +154,7 @@
     "Token": "Text",
     "AddrStr": "Text",
     "HandicapInfo": "Handicap",
-    "Price": "Balance",
+    "Price": "String",
     "OrderId": "u64",
     "TradingPairId": "u32",
     "TradingHistoryIndex": "u64",
@@ -177,8 +177,8 @@
         ]
     },
     "AssetId": "u32",
-    "MiningWeight": "u128",
-    "WeightType": "u128",
+    "MiningWeight": "String",
+    "VoteWeight": "String",
     "ReferralId": "Text",
     "AssetRestriction": {
         "_enum": [
@@ -191,7 +191,7 @@
         ]
     },
     "AssetRestrictions": {
-        "mask": "u32"
+        "bits": "u32"
     },
     "BtcHeader": "Vec<u8>",
     "BtcNetwork": {
@@ -353,7 +353,7 @@
         "isChilled": "bool",
         "lastChilled": "Option<BlockNumber>",
         "total": "Balance",
-        "lastTotalVoteWeight": "WeightType",
+        "lastTotalVoteWeight": "VoteWeight",
         "lastTotalVoteWeightUpdate": "BlockNumber",
         "isValidating": "bool",
         "selfBonded": "Balance",
@@ -384,8 +384,11 @@
         "data": "Vec<RpcOrder>"
     },
     "String": "Text",
-    "Balance": "u128",
-    "MiningPower": "u128",
+    "Balance": "String",
+    "RpcPrice": "Price",
+    "RpcBalance": "Balance",
+    "RpcMiningWeight": "MiningWeight",
+    "RpcVoteWeight": "VoteWeight",
     "FullIdentification": "ValidatorId",
     "WithdrawalRecordOf": "WithdrawalRecord",
     "RpcWithdrawalRecord": {

--- a/scripts/chainx-js/res/chainx_types.json
+++ b/scripts/chainx-js/res/chainx_types.json
@@ -154,7 +154,7 @@
     "Token": "Text",
     "AddrStr": "Text",
     "HandicapInfo": "Handicap",
-    "Price": "String",
+    "Price": "u128",
     "OrderId": "u64",
     "TradingPairId": "u32",
     "TradingHistoryIndex": "u64",
@@ -177,8 +177,8 @@
         ]
     },
     "AssetId": "u32",
-    "MiningWeight": "String",
-    "VoteWeight": "String",
+    "MiningWeight": "u128",
+    "VoteWeight": "u128",
     "ReferralId": "Text",
     "AssetRestriction": {
         "_enum": [
@@ -384,11 +384,11 @@
         "data": "Vec<RpcOrder>"
     },
     "String": "Text",
-    "Balance": "String",
-    "RpcPrice": "Price",
-    "RpcBalance": "Balance",
-    "RpcMiningWeight": "MiningWeight",
-    "RpcVoteWeight": "VoteWeight",
+    "Balance": "u128",
+    "RpcPrice": "String",
+    "RpcBalance": "String",
+    "RpcMiningWeight": "String",
+    "RpcVoteWeight": "String",
     "FullIdentification": "ValidatorId",
     "WithdrawalRecordOf": "WithdrawalRecord",
     "RpcWithdrawalRecord": {

--- a/xpallets/assets/rpc/Cargo.toml
+++ b/xpallets/assets/rpc/Cargo.toml
@@ -9,14 +9,17 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.4" }
-jsonrpc-core = { version = "15.0.0", features = ["arbitrary_precision"] }
-jsonrpc-core-client = { version = "15.0.0", features = ["arbitrary_precision"] }
+jsonrpc-core = "15.0.0"
+jsonrpc-core-client = "15.0.0"
 jsonrpc-derive = "15.0.0"
 
 # Substrate primitives
 sp-api = "2.0.0"
 sp-blockchain = "2.0.0"
 sp-runtime = "2.0.0"
+
+# ChainX pallets
+xpallet-support = { path = "../../support" }
 
 # ChainX pallets api
 xpallet-assets-rpc-runtime-api = { path = "./runtime-api" }

--- a/xpallets/assets/rpc/src/lib.rs
+++ b/xpallets/assets/rpc/src/lib.rs
@@ -65,8 +65,8 @@ where
     C: Send + Sync + 'static,
     C::Api: XAssetsRuntimeApi<Block, AccountId, Balance>,
     Block: BlockT,
-    AccountId: Clone + std::fmt::Display + Codec,
-    Balance: Clone + Copy + std::fmt::Display + std::str::FromStr + Codec + Zero,
+    AccountId: Clone + Display + Codec,
+    Balance: Clone + Copy + Display + FromStr + Codec + Zero,
 {
     fn assets_by_account(
         &self,

--- a/xpallets/assets/src/types.rs
+++ b/xpallets/assets/src/types.rs
@@ -103,7 +103,7 @@ impl<T: Trait> From<AssetErr> for Error<T> {
 
 /// A single lock on a balance. There can be many of these on an account and
 /// they "overlap", so the same balance is frozen by multiple locks.
-#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug)]
+#[derive(Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug)]
 pub struct BalanceLock<Balance> {
     /// An identifier for this lock. Only one lock may be in existence for each
     /// identifier.
@@ -113,8 +113,8 @@ pub struct BalanceLock<Balance> {
     pub amount: Balance,
 }
 
-#[derive(PartialEq, Eq, Clone, Encode, Decode, Default)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
+#[derive(PartialEq, Eq, Clone, Default, Encode, Decode, RuntimeDebug)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct WithdrawalLimit<Balance> {
     pub minimal_withdrawal: Balance,

--- a/xpallets/dex/spot/rpc/Cargo.toml
+++ b/xpallets/dex/spot/rpc/Cargo.toml
@@ -10,14 +10,17 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.4" }
 serde = { version = "1.0.101", features = ["derive"] }
-jsonrpc-core = { version = "15.0.0", features = ["arbitrary_precision"] }
-jsonrpc-core-client = { version = "15.0.0", features = ["arbitrary_precision"] }
+jsonrpc-core = "15.0.0"
+jsonrpc-core-client = "15.0.0"
 jsonrpc-derive = "15.0.0"
 
 # Substrate primitives
 sp-api = "2.0.0"
 sp-blockchain = "2.0.0"
 sp-runtime = "2.0.0"
+
+# ChainX pallets
+xpallet-support = { path = "../../../support" }
 
 # ChainX pallets api
 xpallet-dex-spot-rpc-runtime-api = { path = "./runtime-api" }

--- a/xpallets/dex/spot/rpc/runtime-api/src/lib.rs
+++ b/xpallets/dex/spot/rpc/runtime-api/src/lib.rs
@@ -9,7 +9,9 @@ use sp_std::prelude::*;
 
 use codec::Codec;
 
-pub use xpallet_dex_spot::{Depth, FullPairInfo, Handicap, OrderProperty, RpcOrder, TradingPairInfo, TradingPairId};
+pub use xpallet_dex_spot::{
+    Depth, FullPairInfo, Handicap, OrderProperty, RpcOrder, TradingPairId, TradingPairInfo,
+};
 
 sp_api::decl_runtime_apis! {
     /// The API to query DEX Spot info.

--- a/xpallets/dex/spot/rpc/runtime-api/src/lib.rs
+++ b/xpallets/dex/spot/rpc/runtime-api/src/lib.rs
@@ -9,7 +9,7 @@ use sp_std::prelude::*;
 
 use codec::Codec;
 
-pub use xpallet_dex_spot::{Depth, FullPairInfo, RpcOrder, TradingPairId};
+pub use xpallet_dex_spot::{Depth, FullPairInfo, Handicap, OrderProperty, RpcOrder, TradingPairInfo, TradingPairId};
 
 sp_api::decl_runtime_apis! {
     /// The API to query DEX Spot info.

--- a/xpallets/dex/spot/rpc/src/lib.rs
+++ b/xpallets/dex/spot/rpc/src/lib.rs
@@ -20,8 +20,8 @@ use sp_runtime::{generic::BlockId, traits::Block as BlockT};
 use xpallet_support::{RpcBalance, RpcPrice};
 
 use xpallet_dex_spot_rpc_runtime_api::{
-    Depth, FullPairInfo, Handicap, OrderProperty, RpcOrder, TradingPairId,
-    TradingPairInfo, XSpotApi as XSpotRuntimeApi,
+    Depth, FullPairInfo, Handicap, OrderProperty, RpcOrder, TradingPairId, TradingPairInfo,
+    XSpotApi as XSpotRuntimeApi,
 };
 
 /// XSpot RPC methods.

--- a/xpallets/gateway/common/rpc/Cargo.toml
+++ b/xpallets/gateway/common/rpc/Cargo.toml
@@ -10,14 +10,17 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.4" }
 hex = "0.4"
-jsonrpc-core = { version = "15.0.0", features = ["arbitrary_precision"] }
-jsonrpc-core-client = { version = "15.0.0", features = ["arbitrary_precision"] }
+jsonrpc-core = "15.0.0"
+jsonrpc-core-client = "15.0.0"
 jsonrpc-derive = "15.0.0"
 
 # Substrate primitives
 sp-api = "2.0.0"
 sp-blockchain = "2.0.0"
 sp-runtime = "2.0.0"
+
+# ChainX pallets
+xpallet-support = { path = "../../../support" }
 
 # ChainX pallets api
 xpallet-gateway-common-rpc-runtime-api = { path = "./runtime-api" }

--- a/xpallets/gateway/common/rpc/runtime-api/src/lib.rs
+++ b/xpallets/gateway/common/rpc/runtime-api/src/lib.rs
@@ -11,6 +11,7 @@ use sp_runtime::DispatchError;
 
 pub use chainx_primitives::{AddrStr, AssetId, ChainAddress};
 pub use xp_runtime::Memo;
+
 pub use xpallet_assets::{Chain, WithdrawalLimit};
 pub use xpallet_gateway_common::{
     trustees,

--- a/xpallets/gateway/common/rpc/src/lib.rs
+++ b/xpallets/gateway/common/rpc/src/lib.rs
@@ -22,8 +22,8 @@ use xpallet_gateway_common_rpc_runtime_api::trustees::bitcoin::{
     BtcTrusteeIntentionProps, BtcTrusteeSessionInfo,
 };
 use xpallet_gateway_common_rpc_runtime_api::{
-    AssetId, Chain, GenericTrusteeIntentionProps, GenericTrusteeSessionInfo,
-    WithdrawalLimit, XGatewayCommonApi as XGatewayCommonRuntimeApi,
+    AssetId, Chain, GenericTrusteeIntentionProps, GenericTrusteeSessionInfo, WithdrawalLimit,
+    XGatewayCommonApi as XGatewayCommonRuntimeApi,
 };
 
 /// XGatewayCommon RPC methods.

--- a/xpallets/gateway/common/rpc/src/lib.rs
+++ b/xpallets/gateway/common/rpc/src/lib.rs
@@ -4,6 +4,8 @@
 
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
+use std::fmt::{Debug, Display};
+use std::str::FromStr;
 use std::sync::Arc;
 
 use codec::Codec;
@@ -14,17 +16,22 @@ use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::{generic::BlockId, traits::Block as BlockT};
 
+use xpallet_support::RpcBalance;
+
 use xpallet_gateway_common_rpc_runtime_api::trustees::bitcoin::{
     BtcTrusteeIntentionProps, BtcTrusteeSessionInfo,
 };
 use xpallet_gateway_common_rpc_runtime_api::{
-    AssetId, Chain, GenericTrusteeIntentionProps, GenericTrusteeSessionInfo, WithdrawalLimit,
-    XGatewayCommonApi as XGatewayCommonRuntimeApi,
+    AssetId, Chain, GenericTrusteeIntentionProps, GenericTrusteeSessionInfo,
+    WithdrawalLimit, XGatewayCommonApi as XGatewayCommonRuntimeApi,
 };
 
 /// XGatewayCommon RPC methods.
 #[rpc]
-pub trait XGatewayCommonApi<BlockHash, AccountId, Balance> {
+pub trait XGatewayCommonApi<BlockHash, AccountId, Balance>
+where
+    Balance: Display + FromStr,
+{
     /// Get bound addrs for an accountid
     #[rpc(name = "xgatewaycommon_boundAddrs")]
     fn bound_addrs(
@@ -39,7 +46,7 @@ pub trait XGatewayCommonApi<BlockHash, AccountId, Balance> {
         &self,
         asset_id: AssetId,
         at: Option<BlockHash>,
-    ) -> Result<WithdrawalLimit<Balance>>;
+    ) -> Result<WithdrawalLimit<RpcBalance<Balance>>>;
 
     /// Use the params to verify whether the withdrawal apply is valid. Notice those params is same as the params for call `XGatewayCommon::withdraw(...)`, including checking address is valid or something else. Front-end should use this rpc to check params first, than could create the extrinsic.
     #[rpc(name = "xgatewaycommon_verifyWithdrawal")]
@@ -170,7 +177,7 @@ where
     C: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
     C::Api: XGatewayCommonRuntimeApi<Block, AccountId, Balance>,
     AccountId: Codec + Send + Sync + 'static,
-    Balance: Codec + Send + Sync + 'static + From<u64>,
+    Balance: Codec + Display + FromStr + Send + Sync + 'static + From<u64>,
 {
     fn bound_addrs(
         &self,
@@ -208,7 +215,7 @@ where
         &self,
         asset_id: AssetId,
         at: Option<<Block as BlockT>::Hash>,
-    ) -> Result<WithdrawalLimit<Balance>> {
+    ) -> Result<WithdrawalLimit<RpcBalance<Balance>>> {
         let api = self.client.runtime_api();
         let at = BlockId::hash(at.unwrap_or_else(||
             // If the block hash is not supplied assume the best block.
@@ -218,8 +225,8 @@ where
             .withdrawal_limit(&at, asset_id)
             .map_err(runtime_error_into_rpc_err)?
             .map(|src| WithdrawalLimit {
-                minimal_withdrawal: src.minimal_withdrawal,
-                fee: src.fee,
+                minimal_withdrawal: src.minimal_withdrawal.into(),
+                fee: src.fee.into(),
             })
             .map_err(runtime_error_into_rpc_err)?;
         Ok(result)
@@ -308,9 +315,8 @@ where
 }
 
 const RUNTIME_ERROR: i64 = 1;
-
 /// Converts a runtime trap into an RPC error.
-fn runtime_error_into_rpc_err(err: impl std::fmt::Debug) -> RpcError {
+fn runtime_error_into_rpc_err(err: impl Debug) -> RpcError {
     RpcError {
         code: ErrorCode::ServerError(RUNTIME_ERROR),
         message: "Runtime trapped".into(),

--- a/xpallets/gateway/records/rpc/Cargo.toml
+++ b/xpallets/gateway/records/rpc/Cargo.toml
@@ -10,8 +10,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.4" }
 serde = { version = "1.0.101", features = ["derive"] }
-jsonrpc-core = { version = "15.0.0", features = ["arbitrary_precision"] }
-jsonrpc-core-client = { version = "15.0.0", features = ["arbitrary_precision"] }
+jsonrpc-core = "15.0.0"
+jsonrpc-core-client = "15.0.0"
 jsonrpc-derive = "15.0.0"
 
 # Substrate primitives

--- a/xpallets/mining/asset/rpc/Cargo.toml
+++ b/xpallets/mining/asset/rpc/Cargo.toml
@@ -9,14 +9,17 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.4" }
-jsonrpc-core = { version = "15.0.0", features = ["arbitrary_precision"] }
-jsonrpc-core-client = { version = "15.0.0", features = ["arbitrary_precision"] }
+jsonrpc-core = "15.0.0"
+jsonrpc-core-client = "15.0.0"
 jsonrpc-derive = "15.0.0"
 
 # Substrate primitives
 sp-api = "2.0.0"
 sp-blockchain = "2.0.0"
 sp-runtime = "2.0.0"
+
+# ChainX pallets
+xpallet-support = { path = "../../../support" }
 
 # ChainX pallets api
 xpallet-mining-asset-rpc-runtime-api = { path = "./runtime-api" }

--- a/xpallets/mining/asset/rpc/runtime-api/src/lib.rs
+++ b/xpallets/mining/asset/rpc/runtime-api/src/lib.rs
@@ -10,23 +10,24 @@ use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 use codec::Codec;
 
 pub use chainx_primitives::AssetId;
-pub use xpallet_mining_asset::{MinerLedger, MiningAssetInfo};
+pub use xpallet_mining_asset::{AssetLedger, MinerLedger, MiningAssetInfo, MiningWeight};
 
 sp_api::decl_runtime_apis! {
     /// The API to query mining asset info.
-    pub trait XMiningAssetApi<AccountId, Balance, BlockNumber>
+    pub trait XMiningAssetApi<AccountId, Balance, MiningWeight, BlockNumber>
     where
         AccountId: Codec,
         Balance: Codec,
+        MiningWeight: Codec,
         BlockNumber: Codec,
     {
         /// Get overall information about all mining assets.
-        fn mining_assets() -> Vec<MiningAssetInfo<AccountId, Balance, BlockNumber>>;
+        fn mining_assets() -> Vec<MiningAssetInfo<AccountId, Balance, MiningWeight, BlockNumber>>;
 
         /// Get the asset mining dividends info given the asset miner AccountId.
         fn mining_dividend(who: AccountId) -> BTreeMap<AssetId, Balance>;
 
         /// Get the mining ledger details given the asset miner AccountId.
-        fn miner_ledger(who: AccountId) -> BTreeMap<AssetId, MinerLedger<BlockNumber>>;
+        fn miner_ledger(who: AccountId) -> BTreeMap<AssetId, MinerLedger<MiningWeight, BlockNumber>>;
     }
 }

--- a/xpallets/mining/asset/rpc/src/lib.rs
+++ b/xpallets/mining/asset/rpc/src/lib.rs
@@ -3,6 +3,8 @@
 //! RPC interface for the transaction payment module.
 
 use std::collections::btree_map::BTreeMap;
+use std::fmt::{Debug, Display};
+use std::str::FromStr;
 use std::sync::Arc;
 
 use codec::Codec;
@@ -13,19 +15,24 @@ use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::{generic::BlockId, traits::Block as BlockT};
 
+use xpallet_support::RpcBalance;
+
 use xpallet_mining_asset_rpc_runtime_api::{
     AssetId, MinerLedger, MiningAssetInfo, XMiningAssetApi as XMiningAssetRuntimeApi,
 };
 
 /// XMiningAsset RPC methods.
 #[rpc]
-pub trait XMiningAssetApi<BlockHash, AccountId, Balance, BlockNumber> {
+pub trait XMiningAssetApi<BlockHash, AccountId, Balance, BlockNumber>
+where
+    Balance: Display + FromStr,
+{
     /// Get overall information about all mining assets.
     #[rpc(name = "xminingasset_getMiningAssets")]
     fn mining_assets(
         &self,
         at: Option<BlockHash>,
-    ) -> Result<Vec<MiningAssetInfo<AccountId, Balance, BlockNumber>>>;
+    ) -> Result<Vec<MiningAssetInfo<AccountId, RpcBalance<Balance>, BlockNumber>>>;
 
     /// Get the asset mining dividends info given the asset miner AccountId.
     #[rpc(name = "xminingasset_getDividendByAccount")]
@@ -33,7 +40,7 @@ pub trait XMiningAssetApi<BlockHash, AccountId, Balance, BlockNumber> {
         &self,
         who: AccountId,
         at: Option<BlockHash>,
-    ) -> Result<BTreeMap<AssetId, Balance>>;
+    ) -> Result<BTreeMap<AssetId, RpcBalance<Balance>>>;
 
     /// Get the mining ledger details given the asset miner AccountId.
     #[rpc(name = "xminingasset_getMinerLedgerByAccount")]
@@ -68,27 +75,47 @@ where
     C: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
     C::Api: XMiningAssetRuntimeApi<Block, AccountId, Balance, BlockNumber>,
     AccountId: Codec,
-    Balance: Codec,
+    Balance: Codec + Display + FromStr,
     BlockNumber: Codec,
 {
     fn mining_assets(
         &self,
         at: Option<<Block as BlockT>::Hash>,
-    ) -> Result<Vec<MiningAssetInfo<AccountId, Balance, BlockNumber>>> {
+    ) -> Result<Vec<MiningAssetInfo<AccountId, RpcBalance<Balance>, BlockNumber>>> {
         let api = self.client.runtime_api();
         let at = BlockId::hash(at.unwrap_or_else(|| self.client.info().best_hash));
-        Ok(api.mining_assets(&at).map_err(runtime_error_into_rpc_err)?)
+        Ok(api
+            .mining_assets(&at)
+            .map(|mining_assets| {
+                mining_assets
+                    .into_iter()
+                    .map(|mining_asset| MiningAssetInfo {
+                        asset_id: mining_asset.asset_id,
+                        mining_power: mining_asset.mining_power,
+                        reward_pot: mining_asset.reward_pot,
+                        reward_pot_balance: mining_asset.reward_pot_balance.into(),
+                        ledger_info: mining_asset.ledger_info,
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .map_err(runtime_error_into_rpc_err)?)
     }
 
     fn mining_dividend(
         &self,
         who: AccountId,
         at: Option<<Block as BlockT>::Hash>,
-    ) -> Result<BTreeMap<AssetId, Balance>> {
+    ) -> Result<BTreeMap<AssetId, RpcBalance<Balance>>> {
         let api = self.client.runtime_api();
         let at = BlockId::hash(at.unwrap_or_else(|| self.client.info().best_hash));
         Ok(api
             .mining_dividend(&at, who)
+            .map(|mining_dividend| {
+                mining_dividend
+                    .into_iter()
+                    .map(|(id, balance)| (id, balance.into()))
+                    .collect()
+            })
             .map_err(runtime_error_into_rpc_err)?)
     }
 
@@ -123,9 +150,8 @@ impl From<Error> for i64 {
 }
 
 const RUNTIME_ERROR: i64 = 1;
-
 /// Converts a runtime trap into an RPC error.
-fn runtime_error_into_rpc_err(err: impl std::fmt::Debug) -> RpcError {
+fn runtime_error_into_rpc_err(err: impl Debug) -> RpcError {
     RpcError {
         code: ErrorCode::ServerError(RUNTIME_ERROR),
         message: "Runtime trapped".into(),

--- a/xpallets/mining/asset/src/impls.rs
+++ b/xpallets/mining/asset/src/impls.rs
@@ -5,13 +5,16 @@ use sp_core::crypto::UncheckedFrom;
 use sp_runtime::traits::{Hash, Saturating};
 
 use xp_mining_common::{
-    generic_weight_factors, BaseMiningWeight, Claim, ComputeMiningWeight, WeightFactors, WeightType,
+    generic_weight_factors, BaseMiningWeightHandle, Claim, ComputeMiningWeight, WeightFactors,
+    WeightType,
 };
 use xp_mining_staking::MiningPower;
 
 use super::*;
 
-impl<'a, T: Trait> BaseMiningWeight<BalanceOf<T>, T::BlockNumber> for AssetLedgerWrapper<'a, T> {
+impl<'a, T: Trait> BaseMiningWeightHandle<BalanceOf<T>, T::BlockNumber>
+    for AssetLedgerWrapper<'a, T>
+{
     fn amount(&self) -> BalanceOf<T> {
         xpallet_assets::Module::<T>::total_issuance(&self.asset_id)
     }
@@ -33,7 +36,9 @@ impl<'a, T: Trait> BaseMiningWeight<BalanceOf<T>, T::BlockNumber> for AssetLedge
     }
 }
 
-impl<'a, T: Trait> BaseMiningWeight<BalanceOf<T>, T::BlockNumber> for MinerLedgerWrapper<'a, T> {
+impl<'a, T: Trait> BaseMiningWeightHandle<BalanceOf<T>, T::BlockNumber>
+    for MinerLedgerWrapper<'a, T>
+{
     fn amount(&self) -> BalanceOf<T> {
         xpallet_assets::Module::<T>::all_type_asset_balance(&self.miner, &self.asset_id)
     }

--- a/xpallets/mining/asset/src/impls.rs
+++ b/xpallets/mining/asset/src/impls.rs
@@ -5,16 +5,13 @@ use sp_core::crypto::UncheckedFrom;
 use sp_runtime::traits::{Hash, Saturating};
 
 use xp_mining_common::{
-    generic_weight_factors, BaseMiningWeightHandle, Claim, ComputeMiningWeight, WeightFactors,
-    WeightType,
+    generic_weight_factors, BaseMiningWeight, Claim, ComputeMiningWeight, WeightFactors, WeightType,
 };
 use xp_mining_staking::MiningPower;
 
 use super::*;
 
-impl<'a, T: Trait> BaseMiningWeightHandle<BalanceOf<T>, T::BlockNumber>
-    for AssetLedgerWrapper<'a, T>
-{
+impl<'a, T: Trait> BaseMiningWeight<BalanceOf<T>, T::BlockNumber> for AssetLedgerWrapper<'a, T> {
     fn amount(&self) -> BalanceOf<T> {
         xpallet_assets::Module::<T>::total_issuance(&self.asset_id)
     }
@@ -36,9 +33,7 @@ impl<'a, T: Trait> BaseMiningWeightHandle<BalanceOf<T>, T::BlockNumber>
     }
 }
 
-impl<'a, T: Trait> BaseMiningWeightHandle<BalanceOf<T>, T::BlockNumber>
-    for MinerLedgerWrapper<'a, T>
-{
+impl<'a, T: Trait> BaseMiningWeight<BalanceOf<T>, T::BlockNumber> for MinerLedgerWrapper<'a, T> {
     fn amount(&self) -> BalanceOf<T> {
         xpallet_assets::Module::<T>::all_type_asset_balance(&self.miner, &self.asset_id)
     }

--- a/xpallets/mining/asset/src/lib.rs
+++ b/xpallets/mining/asset/src/lib.rs
@@ -17,6 +17,8 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
+use sp_std::prelude::*;
+
 use frame_support::{
     decl_error, decl_event, decl_module, decl_storage,
     dispatch::{DispatchError, DispatchResult},
@@ -26,24 +28,19 @@ use frame_support::{
 };
 use frame_system::{ensure_root, ensure_signed};
 use sp_runtime::traits::{SaturatedConversion, Zero};
-use sp_std::prelude::*;
 
 use chainx_primitives::AssetId;
 use xp_mining_common::{
-    Claim, ComputeMiningWeight, MiningWeight, RewardPotAccountFor, WeightType,
+    Claim, ComputeMiningWeight, MiningWeightHandle, RewardPotAccountFor, WeightType,
     ZeroMiningWeightError,
 };
-use xpallet_assets::AssetType;
+use xpallet_assets::{AssetType, BalanceOf};
 use xpallet_support::{traits::TreasuryAccount, warn};
 
-pub use impls::SimpleAssetRewardPotAccountDeterminer;
-pub use rpc::*;
-pub use types::*;
-pub use weight_info::WeightInfo;
-
-pub type BalanceOf<T> = <<T as xpallet_assets::Trait>::Currency as Currency<
-    <T as frame_system::Trait>::AccountId,
->>::Balance;
+pub use self::impls::SimpleAssetRewardPotAccountDeterminer;
+pub use self::rpc::*;
+pub use self::types::*;
+pub use self::weight_info::WeightInfo;
 
 pub trait Trait: xpallet_assets::Trait {
     /// The overarching event type.
@@ -109,12 +106,12 @@ decl_storage! {
 
         /// Mining weight information of the mining assets.
         pub AssetLedgers get(fn asset_ledgers):
-            map hasher(twox_64_concat) AssetId => AssetLedger<T::BlockNumber>;
+            map hasher(twox_64_concat) AssetId => AssetLedger<MiningWeight, T::BlockNumber>;
 
         /// The map from nominator to the vote weight ledger of all mining assets.
         pub MinerLedgers get(fn miner_ledgers):
             double_map hasher(twox_64_concat) T::AccountId, hasher(twox_64_concat) AssetId
-            => MinerLedger<T::BlockNumber>;
+            => MinerLedger<MiningWeight, T::BlockNumber>;
 
         /// Mining power map of X-type assets.
         pub FixedAssetPowerOf get(fn fixed_asset_power_of):
@@ -297,7 +294,7 @@ impl<T: Trait> Module<T> {
             MinerLedgers::<T>::insert(
                 who,
                 asset_id,
-                MinerLedger::<T::BlockNumber> {
+                MinerLedger::<MiningWeight, T::BlockNumber> {
                     last_mining_weight_update: current_block,
                     ..Default::default()
                 },

--- a/xpallets/mining/asset/src/lib.rs
+++ b/xpallets/mining/asset/src/lib.rs
@@ -31,7 +31,7 @@ use sp_runtime::traits::{SaturatedConversion, Zero};
 
 use chainx_primitives::AssetId;
 use xp_mining_common::{
-    Claim, ComputeMiningWeight, MiningWeightHandle, RewardPotAccountFor, WeightType,
+    Claim, ComputeMiningWeight, MiningWeight as _, RewardPotAccountFor, WeightType,
     ZeroMiningWeightError,
 };
 use xpallet_assets::{AssetType, BalanceOf};

--- a/xpallets/mining/asset/src/rpc.rs
+++ b/xpallets/mining/asset/src/rpc.rs
@@ -1,12 +1,15 @@
 // Copyright 2019-2020 ChainX Project Authors. Licensed under GPL-3.0.
 
-use super::*;
+use sp_std::collections::btree_map::BTreeMap;
+
 use codec::{Decode, Encode};
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
+
 use frame_support::storage::IterableStorageDoubleMap;
 use sp_runtime::RuntimeDebug;
-#[cfg(feature = "std")]
-use sp_runtime::{Deserialize, Serialize};
-use sp_std::collections::btree_map::BTreeMap;
+
+use super::*;
 
 /// Mining asset info.
 #[derive(PartialEq, Eq, Clone, Default, Encode, Decode, RuntimeDebug)]

--- a/xpallets/mining/asset/src/rpc.rs
+++ b/xpallets/mining/asset/src/rpc.rs
@@ -1,15 +1,21 @@
 // Copyright 2019-2020 ChainX Project Authors. Licensed under GPL-3.0.
 
-use sp_std::collections::btree_map::BTreeMap;
+use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
 
 use codec::{Decode, Encode};
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 
-use frame_support::storage::IterableStorageDoubleMap;
+use frame_support::storage::{IterableStorageDoubleMap, StorageMap, StorageValue};
 use sp_runtime::RuntimeDebug;
 
-use crate::*;
+use chainx_primitives::AssetId;
+use xp_mining_common::RewardPotAccountFor;
+
+use crate::{
+    types::*, AssetLedgers, BalanceOf, FixedAssetPowerOf, MinerLedgers, MiningPrevilegedAssets,
+    Module, Trait,
+};
 
 /// Mining asset info.
 #[derive(PartialEq, Eq, Clone, Default, Encode, Decode, RuntimeDebug)]

--- a/xpallets/mining/asset/src/types.rs
+++ b/xpallets/mining/asset/src/types.rs
@@ -6,10 +6,11 @@ use serde::{Deserialize, Serialize};
 use sp_runtime::RuntimeDebug;
 
 use chainx_primitives::AssetId;
+use xp_mining_common::WeightType;
 
 use crate::Trait;
 
-pub type MiningWeight = u128;
+pub type MiningWeight = WeightType;
 pub type FixedAssetPower = u32;
 pub type StakingRequirement = u32;
 
@@ -17,9 +18,8 @@ pub type StakingRequirement = u32;
 #[derive(PartialEq, Eq, Clone, Default, Encode, Decode, RuntimeDebug)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
-pub struct AssetLedger<BlockNumber> {
+pub struct AssetLedger<MiningWeight, BlockNumber> {
     /// Last calculated total vote weight of current validator.
-    #[cfg_attr(feature = "std", serde(with = "xpallet_support::serde_num_str"))]
     pub last_total_mining_weight: MiningWeight,
     /// Block number at which point `last_total_vote_weight` just updated.
     pub last_total_mining_weight_update: BlockNumber,
@@ -27,11 +27,14 @@ pub struct AssetLedger<BlockNumber> {
 
 pub struct AssetLedgerWrapper<'a, T: Trait> {
     pub asset_id: &'a AssetId,
-    pub inner: &'a mut AssetLedger<T::BlockNumber>,
+    pub inner: &'a mut AssetLedger<MiningWeight, T::BlockNumber>,
 }
 
 impl<'a, T: Trait> AssetLedgerWrapper<'a, T> {
-    pub fn new(asset_id: &'a AssetId, inner: &'a mut AssetLedger<T::BlockNumber>) -> Self {
+    pub fn new(
+        asset_id: &'a AssetId,
+        inner: &'a mut AssetLedger<MiningWeight, T::BlockNumber>,
+    ) -> Self {
         Self { asset_id, inner }
     }
 }
@@ -44,9 +47,8 @@ impl<'a, T: Trait> AssetLedgerWrapper<'a, T> {
 #[derive(PartialEq, Eq, Clone, Default, Encode, Decode, RuntimeDebug)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
-pub struct MinerLedger<BlockNumber> {
+pub struct MinerLedger<MiningWeight, BlockNumber> {
     /// Last calculated total vote weight of current validator.
-    #[cfg_attr(feature = "std", serde(with = "xpallet_support::serde_num_str"))]
     pub last_mining_weight: MiningWeight,
     /// Block number at which point `last_total_vote_weight` just updated.
     pub last_mining_weight_update: BlockNumber,
@@ -57,14 +59,14 @@ pub struct MinerLedger<BlockNumber> {
 pub struct MinerLedgerWrapper<'a, T: Trait> {
     pub miner: &'a T::AccountId,
     pub asset_id: &'a AssetId,
-    pub inner: &'a mut MinerLedger<T::BlockNumber>,
+    pub inner: &'a mut MinerLedger<MiningWeight, T::BlockNumber>,
 }
 
 impl<'a, T: Trait> MinerLedgerWrapper<'a, T> {
     pub fn new(
         miner: &'a T::AccountId,
         asset_id: &'a AssetId,
-        inner: &'a mut MinerLedger<T::BlockNumber>,
+        inner: &'a mut MinerLedger<MiningWeight, T::BlockNumber>,
     ) -> Self {
         Self {
             miner,

--- a/xpallets/mining/asset/src/types.rs
+++ b/xpallets/mining/asset/src/types.rs
@@ -1,11 +1,13 @@
 // Copyright 2019-2020 ChainX Project Authors. Licensed under GPL-3.0.
 
-use crate::Trait;
-use chainx_primitives::AssetId;
 use codec::{Decode, Encode};
-use sp_runtime::RuntimeDebug;
 #[cfg(feature = "std")]
-use sp_runtime::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
+use sp_runtime::RuntimeDebug;
+
+use chainx_primitives::AssetId;
+
+use crate::Trait;
 
 pub type MiningWeight = u128;
 pub type FixedAssetPower = u32;
@@ -17,6 +19,7 @@ pub type StakingRequirement = u32;
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct AssetLedger<BlockNumber> {
     /// Last calculated total vote weight of current validator.
+    #[cfg_attr(feature = "std", serde(with = "xpallet_support::serde_num_str"))]
     pub last_total_mining_weight: MiningWeight,
     /// Block number at which point `last_total_vote_weight` just updated.
     pub last_total_mining_weight_update: BlockNumber,
@@ -43,6 +46,7 @@ impl<'a, T: Trait> AssetLedgerWrapper<'a, T> {
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct MinerLedger<BlockNumber> {
     /// Last calculated total vote weight of current validator.
+    #[cfg_attr(feature = "std", serde(with = "xpallet_support::serde_num_str"))]
     pub last_mining_weight: MiningWeight,
     /// Block number at which point `last_total_vote_weight` just updated.
     pub last_mining_weight_update: BlockNumber,

--- a/xpallets/mining/staking/rpc/Cargo.toml
+++ b/xpallets/mining/staking/rpc/Cargo.toml
@@ -9,14 +9,17 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.4" }
-jsonrpc-core = { version = "15.0.0", features = ["arbitrary_precision"] }
-jsonrpc-core-client = { version = "15.0.0", features = ["arbitrary_precision"] }
+jsonrpc-core = "15.0.0"
+jsonrpc-core-client = "15.0.0"
 jsonrpc-derive = "15.0.0"
 
 # Substrate primitives
 sp-api = "2.0.0"
 sp-blockchain = "2.0.0"
 sp-runtime = "2.0.0"
+
+# ChainX pallets
+xpallet-support = { path = "../../../support" }
 
 # ChainX pallets api
 xpallet-mining-staking-rpc-runtime-api = { path = "./runtime-api" }

--- a/xpallets/mining/staking/rpc/runtime-api/src/lib.rs
+++ b/xpallets/mining/staking/rpc/runtime-api/src/lib.rs
@@ -9,7 +9,9 @@ use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 
 use codec::Codec;
 
-pub use xpallet_mining_staking::{NominatorInfo, NominatorLedger, ValidatorInfo, ValidatorLedger, Unbonded};
+pub use xpallet_mining_staking::{
+    NominatorInfo, NominatorLedger, Unbonded, ValidatorInfo, ValidatorLedger,
+};
 
 sp_api::decl_runtime_apis! {
     /// The API to query Staking info.

--- a/xpallets/mining/staking/rpc/runtime-api/src/lib.rs
+++ b/xpallets/mining/staking/rpc/runtime-api/src/lib.rs
@@ -9,7 +9,7 @@ use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 
 use codec::Codec;
 
-pub use xpallet_mining_staking::{NominatorInfo, NominatorLedger, ValidatorInfo};
+pub use xpallet_mining_staking::{NominatorInfo, NominatorLedger, ValidatorInfo, ValidatorLedger, Unbonded};
 
 sp_api::decl_runtime_apis! {
     /// The API to query Staking info.

--- a/xpallets/mining/staking/rpc/runtime-api/src/lib.rs
+++ b/xpallets/mining/staking/rpc/runtime-api/src/lib.rs
@@ -10,28 +10,29 @@ use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 use codec::Codec;
 
 pub use xpallet_mining_staking::{
-    NominatorInfo, NominatorLedger, Unbonded, ValidatorInfo, ValidatorLedger,
+    NominatorInfo, NominatorLedger, Unbonded, ValidatorInfo, ValidatorLedger, VoteWeight,
 };
 
 sp_api::decl_runtime_apis! {
     /// The API to query Staking info.
-    pub trait XStakingApi<AccountId, Balance, BlockNumber>
+    pub trait XStakingApi<AccountId, Balance, VoteWeight, BlockNumber>
     where
         AccountId: Codec + Ord,
         Balance: Codec,
+        VoteWeight: Codec,
         BlockNumber: Codec,
     {
         /// Get overall information about all potential validators.
-        fn validators() -> Vec<ValidatorInfo<AccountId, Balance, BlockNumber>>;
+        fn validators() -> Vec<ValidatorInfo<AccountId, Balance, VoteWeight, BlockNumber>>;
 
         /// Get overall information given the validator AccountId.
-        fn validator_info_of(who: AccountId) -> ValidatorInfo<AccountId, Balance, BlockNumber>;
+        fn validator_info_of(who: AccountId) -> ValidatorInfo<AccountId, Balance, VoteWeight, BlockNumber>;
 
         /// Get the staking dividends info given the staker AccountId.
         fn staking_dividend_of(who: AccountId) -> BTreeMap<AccountId, Balance>;
 
         /// Get the nomination details given the staker AccountId.
-        fn nomination_details_of(who: AccountId) -> BTreeMap<AccountId, NominatorLedger<Balance, BlockNumber>>;
+        fn nomination_details_of(who: AccountId) -> BTreeMap<AccountId, NominatorLedger<Balance, VoteWeight, BlockNumber>>;
 
         /// Get individual nominator information given the nominator AccountId.
         fn nominator_info_of(who: AccountId) -> NominatorInfo<BlockNumber>;

--- a/xpallets/mining/staking/rpc/src/lib.rs
+++ b/xpallets/mining/staking/rpc/src/lib.rs
@@ -3,6 +3,8 @@
 //! RPC interface for the transaction payment module.
 
 use std::collections::btree_map::BTreeMap;
+use std::fmt::{Debug, Display};
+use std::str::FromStr;
 use std::sync::Arc;
 
 use codec::Codec;
@@ -13,8 +15,11 @@ use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::{generic::BlockId, traits::Block as BlockT};
 
+use xpallet_support::RpcBalance;
+
 use xpallet_mining_staking_rpc_runtime_api::{
-    NominatorInfo, NominatorLedger, ValidatorInfo, XStakingApi as XStakingRuntimeApi,
+    NominatorInfo, NominatorLedger, Unbonded, ValidatorInfo, ValidatorLedger,
+    XStakingApi as XStakingRuntimeApi,
 };
 
 /// XStaking RPC methods.
@@ -22,13 +27,14 @@ use xpallet_mining_staking_rpc_runtime_api::{
 pub trait XStakingApi<BlockHash, AccountId, Balance, BlockNumber>
 where
     AccountId: Ord,
+    Balance: Display + FromStr,
 {
     /// Get overall information about all potential validators
     #[rpc(name = "xstaking_getValidators")]
     fn validators(
         &self,
         at: Option<BlockHash>,
-    ) -> Result<Vec<ValidatorInfo<AccountId, Balance, BlockNumber>>>;
+    ) -> Result<Vec<ValidatorInfo<AccountId, RpcBalance<Balance>, BlockNumber>>>;
 
     /// Get overall information given the validator AccountId.
     #[rpc(name = "xstaking_getValidatorByAccount")]
@@ -36,7 +42,7 @@ where
         &self,
         who: AccountId,
         at: Option<BlockHash>,
-    ) -> Result<ValidatorInfo<AccountId, Balance, BlockNumber>>;
+    ) -> Result<ValidatorInfo<AccountId, RpcBalance<Balance>, BlockNumber>>;
 
     /// Get the staking dividends info given the staker AccountId.
     #[rpc(name = "xstaking_getDividendByAccount")]
@@ -44,7 +50,7 @@ where
         &self,
         who: AccountId,
         at: Option<BlockHash>,
-    ) -> Result<BTreeMap<AccountId, Balance>>;
+    ) -> Result<BTreeMap<AccountId, RpcBalance<Balance>>>;
 
     /// Get the nomination details given the staker AccountId.
     #[rpc(name = "xstaking_getNominationByAccount")]
@@ -52,7 +58,7 @@ where
         &self,
         who: AccountId,
         at: Option<BlockHash>,
-    ) -> Result<BTreeMap<AccountId, NominatorLedger<Balance, BlockNumber>>>;
+    ) -> Result<BTreeMap<AccountId, NominatorLedger<RpcBalance<Balance>, BlockNumber>>>;
 
     /// Get individual nominator information given the nominator AccountId.
     #[rpc(name = "xstaking_getNominatorByAccount")]
@@ -86,27 +92,62 @@ where
     C: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
     C::Api: XStakingRuntimeApi<Block, AccountId, Balance, BlockNumber>,
     AccountId: Codec + Ord,
-    Balance: Codec,
+    Balance: Codec + Display + FromStr,
     BlockNumber: Codec,
 {
     fn validators(
         &self,
         at: Option<<Block as BlockT>::Hash>,
-    ) -> Result<Vec<ValidatorInfo<AccountId, Balance, BlockNumber>>> {
+    ) -> Result<Vec<ValidatorInfo<AccountId, RpcBalance<Balance>, BlockNumber>>> {
         let api = self.client.runtime_api();
         let at = BlockId::hash(at.unwrap_or_else(|| self.client.info().best_hash));
-        Ok(api.validators(&at).map_err(runtime_error_into_rpc_err)?)
+        Ok(api
+            .validators(&at)
+            .map(|validators| {
+                validators
+                    .into_iter()
+                    .map(|validator| ValidatorInfo {
+                        account: validator.account,
+                        profile: validator.profile,
+                        ledger: ValidatorLedger {
+                            total_nomination: validator.ledger.total_nomination.into(),
+                            last_total_vote_weight: validator.ledger.last_total_vote_weight,
+                            last_total_vote_weight_update: validator
+                                .ledger
+                                .last_total_vote_weight_update,
+                        },
+                        is_validating: validator.is_validating,
+                        self_bonded: validator.self_bonded.into(),
+                        reward_pot_account: validator.reward_pot_account,
+                        reward_pot_balance: validator.reward_pot_balance.into(),
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .map_err(runtime_error_into_rpc_err)?)
     }
 
     fn validator_info_of(
         &self,
         who: AccountId,
         at: Option<<Block as BlockT>::Hash>,
-    ) -> Result<ValidatorInfo<AccountId, Balance, BlockNumber>> {
+    ) -> Result<ValidatorInfo<AccountId, RpcBalance<Balance>, BlockNumber>> {
         let api = self.client.runtime_api();
         let at = BlockId::hash(at.unwrap_or_else(|| self.client.info().best_hash));
         Ok(api
             .validator_info_of(&at, who)
+            .map(|validator| ValidatorInfo {
+                account: validator.account,
+                profile: validator.profile,
+                ledger: ValidatorLedger {
+                    total_nomination: validator.ledger.total_nomination.into(),
+                    last_total_vote_weight: validator.ledger.last_total_vote_weight,
+                    last_total_vote_weight_update: validator.ledger.last_total_vote_weight_update,
+                },
+                is_validating: validator.is_validating,
+                self_bonded: validator.self_bonded.into(),
+                reward_pot_account: validator.reward_pot_account,
+                reward_pot_balance: validator.reward_pot_balance.into(),
+            })
             .map_err(runtime_error_into_rpc_err)?)
     }
 
@@ -114,11 +155,17 @@ where
         &self,
         who: AccountId,
         at: Option<<Block as BlockT>::Hash>,
-    ) -> Result<BTreeMap<AccountId, Balance>> {
+    ) -> Result<BTreeMap<AccountId, RpcBalance<Balance>>> {
         let api = self.client.runtime_api();
         let at = BlockId::hash(at.unwrap_or_else(|| self.client.info().best_hash));
         Ok(api
             .staking_dividend_of(&at, who)
+            .map(|staking_dividend| {
+                staking_dividend
+                    .into_iter()
+                    .map(|(account, balance)| (account, balance.into()))
+                    .collect()
+            })
             .map_err(runtime_error_into_rpc_err)?)
     }
 
@@ -126,11 +173,34 @@ where
         &self,
         who: AccountId,
         at: Option<<Block as BlockT>::Hash>,
-    ) -> Result<BTreeMap<AccountId, NominatorLedger<Balance, BlockNumber>>> {
+    ) -> Result<BTreeMap<AccountId, NominatorLedger<RpcBalance<Balance>, BlockNumber>>> {
         let api = self.client.runtime_api();
         let at = BlockId::hash(at.unwrap_or_else(|| self.client.info().best_hash));
         Ok(api
             .nomination_details_of(&at, who)
+            .map(|nomination_details| {
+                nomination_details
+                    .into_iter()
+                    .map(|(account, nominator_ledger)| {
+                        (
+                            account,
+                            NominatorLedger {
+                                nomination: nominator_ledger.nomination.into(),
+                                last_vote_weight: nominator_ledger.last_vote_weight,
+                                last_vote_weight_update: nominator_ledger.last_vote_weight_update,
+                                unbonded_chunks: nominator_ledger
+                                    .unbonded_chunks
+                                    .into_iter()
+                                    .map(|unbonded| Unbonded {
+                                        value: unbonded.value.into(),
+                                        locked_until: unbonded.locked_until,
+                                    })
+                                    .collect(),
+                            },
+                        )
+                    })
+                    .collect()
+            })
             .map_err(runtime_error_into_rpc_err)?)
     }
 
@@ -165,9 +235,8 @@ impl From<Error> for i64 {
 }
 
 const RUNTIME_ERROR: i64 = 1;
-
 /// Converts a runtime trap into an RPC error.
-fn runtime_error_into_rpc_err(err: impl std::fmt::Debug) -> RpcError {
+fn runtime_error_into_rpc_err(err: impl Debug) -> RpcError {
     RpcError {
         code: ErrorCode::ServerError(RUNTIME_ERROR),
         message: "Runtime trapped".into(),

--- a/xpallets/mining/staking/src/impls.rs
+++ b/xpallets/mining/staking/src/impls.rs
@@ -9,14 +9,13 @@ use sp_runtime::{traits::Hash, Perbill};
 use sp_staking::offence::{OffenceDetails, OnOffenceHandler};
 
 use xp_mining_common::{
-    generic_weight_factors, BaseMiningWeightHandle, Claim, ComputeMiningWeight, WeightFactors,
-    WeightType,
+    generic_weight_factors, BaseMiningWeight, Claim, ComputeMiningWeight, WeightFactors, WeightType,
 };
 use xp_mining_staking::SessionIndex;
 
 use crate::*;
 
-impl<Balance, BlockNumber> BaseMiningWeightHandle<Balance, BlockNumber>
+impl<Balance, BlockNumber> BaseMiningWeight<Balance, BlockNumber>
     for ValidatorLedger<Balance, VoteWeight, BlockNumber>
 where
     Balance: Default + BaseArithmetic + Copy,
@@ -47,7 +46,7 @@ where
     }
 }
 
-impl<Balance, BlockNumber> BaseMiningWeightHandle<Balance, BlockNumber>
+impl<Balance, BlockNumber> BaseMiningWeight<Balance, BlockNumber>
     for NominatorLedger<Balance, VoteWeight, BlockNumber>
 where
     Balance: Default + BaseArithmetic + Copy,

--- a/xpallets/mining/staking/src/impls.rs
+++ b/xpallets/mining/staking/src/impls.rs
@@ -1,19 +1,23 @@
 // Copyright 2019-2020 ChainX Project Authors. Licensed under GPL-3.0.
 
-use super::*;
+use sp_std::cmp::Ordering;
+
 use codec::Encode;
 use sp_arithmetic::traits::BaseArithmetic;
 use sp_core::crypto::UncheckedFrom;
 use sp_runtime::{traits::Hash, Perbill};
 use sp_staking::offence::{OffenceDetails, OnOffenceHandler};
-use sp_std::cmp::Ordering;
+
 use xp_mining_common::{
-    generic_weight_factors, BaseMiningWeight, Claim, ComputeMiningWeight, WeightFactors,
+    generic_weight_factors, BaseMiningWeightHandle, Claim, ComputeMiningWeight, WeightFactors,
+    WeightType,
 };
 use xp_mining_staking::SessionIndex;
 
-impl<Balance, BlockNumber> BaseMiningWeight<Balance, BlockNumber>
-    for ValidatorLedger<Balance, BlockNumber>
+use crate::*;
+
+impl<Balance, BlockNumber> BaseMiningWeightHandle<Balance, BlockNumber>
+    for ValidatorLedger<Balance, VoteWeight, BlockNumber>
 where
     Balance: Default + BaseArithmetic + Copy,
     BlockNumber: Default + BaseArithmetic + Copy,
@@ -43,8 +47,8 @@ where
     }
 }
 
-impl<Balance, BlockNumber> BaseMiningWeight<Balance, BlockNumber>
-    for NominatorLedger<Balance, BlockNumber>
+impl<Balance, BlockNumber> BaseMiningWeightHandle<Balance, BlockNumber>
+    for NominatorLedger<Balance, VoteWeight, BlockNumber>
 where
     Balance: Default + BaseArithmetic + Copy,
     BlockNumber: Default + BaseArithmetic + Copy,

--- a/xpallets/mining/staking/src/rpc.rs
+++ b/xpallets/mining/staking/src/rpc.rs
@@ -1,12 +1,15 @@
 // Copyright 2019-2020 ChainX Project Authors. Licensed under GPL-3.0.
 
-use super::*;
+use sp_std::{collections::btree_map::BTreeMap};
+
 use codec::{Decode, Encode};
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
+
 use frame_support::storage::IterableStorageDoubleMap;
 use sp_runtime::RuntimeDebug;
-#[cfg(feature = "std")]
-use sp_runtime::{Deserialize, Serialize};
-use sp_std::collections::btree_map::BTreeMap;
+
+use super::*;
 
 /// Total information about a validator.
 #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]

--- a/xpallets/mining/staking/src/rpc.rs
+++ b/xpallets/mining/staking/src/rpc.rs
@@ -1,6 +1,6 @@
 // Copyright 2019-2020 ChainX Project Authors. Licensed under GPL-3.0.
 
-use sp_std::{collections::btree_map::BTreeMap};
+use sp_std::collections::btree_map::BTreeMap;
 
 use codec::{Decode, Encode};
 #[cfg(feature = "std")]

--- a/xpallets/mining/staking/src/rpc.rs
+++ b/xpallets/mining/staking/src/rpc.rs
@@ -1,15 +1,20 @@
 // Copyright 2019-2020 ChainX Project Authors. Licensed under GPL-3.0.
 
-use sp_std::collections::btree_map::BTreeMap;
+use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
 
 use codec::{Decode, Encode};
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 
-use frame_support::storage::IterableStorageDoubleMap;
+use frame_support::storage::{IterableStorageDoubleMap, StorageDoubleMap, StorageMap};
 use sp_runtime::RuntimeDebug;
 
-use crate::*;
+use xp_mining_common::RewardPotAccountFor;
+
+use crate::{
+    types::*, BalanceOf, LastRebondOf, Module, Nominations, SessionInterface, Trait,
+    ValidatorLedgers, Validators,
+};
 
 /// Total information about a validator.
 #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]

--- a/xpallets/mining/staking/src/types.rs
+++ b/xpallets/mining/staking/src/types.rs
@@ -1,13 +1,16 @@
 // Copyright 2019-2020 ChainX Project Authors. Licensed under GPL-3.0.
 
-use super::*;
-use chainx_primitives::AssetId;
 use codec::{Decode, Encode};
-use sp_runtime::RuntimeDebug;
 #[cfg(feature = "std")]
-use sp_runtime::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
+
+use sp_runtime::RuntimeDebug;
+
+use chainx_primitives::AssetId;
 use xp_mining_common::WeightType;
 use xp_mining_staking::MiningPower;
+
+use super::*;
 
 /// Detailed types of reserved balances in Staking.
 #[derive(PartialEq, PartialOrd, Ord, Eq, Clone, Copy, Encode, Decode, RuntimeDebug)]
@@ -72,6 +75,7 @@ pub struct NominatorLedger<Balance, BlockNumber> {
     /// The amount of vote.
     pub nomination: Balance,
     /// Last calculated total vote weight of current nominator.
+    #[cfg_attr(feature = "std", serde(with = "xpallet_support::serde_num_str"))]
     pub last_vote_weight: WeightType,
     /// Block number at which point `last_vote_weight` just updated.
     pub last_vote_weight_update: BlockNumber,

--- a/xpallets/mining/staking/src/types.rs
+++ b/xpallets/mining/staking/src/types.rs
@@ -10,7 +10,9 @@ use chainx_primitives::AssetId;
 use xp_mining_common::WeightType;
 use xp_mining_staking::MiningPower;
 
-use super::*;
+use crate::*;
+
+pub type VoteWeight = WeightType;
 
 /// Detailed types of reserved balances in Staking.
 #[derive(PartialEq, PartialOrd, Ord, Eq, Clone, Copy, Encode, Decode, RuntimeDebug)]
@@ -58,11 +60,11 @@ pub struct Unbonded<Balance, BlockNumber> {
 #[derive(PartialEq, Eq, Clone, Default, Encode, Decode, RuntimeDebug)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
-pub struct ValidatorLedger<Balance, BlockNumber> {
+pub struct ValidatorLedger<Balance, VoteWeight, BlockNumber> {
     /// The total amount of all the nominators' vote balances.
     pub total_nomination: Balance,
     /// Last calculated total vote weight of current validator.
-    pub last_total_vote_weight: WeightType,
+    pub last_total_vote_weight: VoteWeight,
     /// Block number at which point `last_total_vote_weight` just updated.
     pub last_total_vote_weight_update: BlockNumber,
 }
@@ -71,12 +73,11 @@ pub struct ValidatorLedger<Balance, BlockNumber> {
 #[derive(PartialEq, Eq, Clone, Default, Encode, Decode, RuntimeDebug)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
-pub struct NominatorLedger<Balance, BlockNumber> {
+pub struct NominatorLedger<Balance, VoteWeight, BlockNumber> {
     /// The amount of vote.
     pub nomination: Balance,
     /// Last calculated total vote weight of current nominator.
-    #[cfg_attr(feature = "std", serde(with = "xpallet_support::serde_num_str"))]
-    pub last_vote_weight: WeightType,
+    pub last_vote_weight: VoteWeight,
     /// Block number at which point `last_vote_weight` just updated.
     pub last_vote_weight_update: BlockNumber,
     /// Unbonded entries.

--- a/xpallets/mining/staking/src/types.rs
+++ b/xpallets/mining/staking/src/types.rs
@@ -1,16 +1,22 @@
 // Copyright 2019-2020 ChainX Project Authors. Licensed under GPL-3.0.
 
+use sp_std::vec::Vec;
+
 use codec::{Decode, Encode};
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 
-use sp_runtime::RuntimeDebug;
+use sp_runtime::{
+    traits::{SaturatedConversion, Saturating},
+    RuntimeDebug,
+};
 
-use chainx_primitives::AssetId;
-use xp_mining_common::WeightType;
+use chainx_primitives::{AssetId, ReferralId};
+use xp_mining_common::{RewardPotAccountFor, WeightType};
 use xp_mining_staking::MiningPower;
+use xpallet_support::debug;
 
-use crate::*;
+use crate::{AssetMining, BalanceOf, EraIndex, Module, Trait};
 
 pub type VoteWeight = WeightType;
 

--- a/xpallets/support/src/lib.rs
+++ b/xpallets/support/src/lib.rs
@@ -14,4 +14,4 @@ pub use frame_support::fail;
 
 pub use self::macros::*;
 #[cfg(feature = "std")]
-pub use self::serde::{serde_hex, serde_text};
+pub use self::serde::{serde_hex, serde_num_str, serde_text, RpcBalance, RpcPrice, RpcU128};

--- a/xpallets/support/src/lib.rs
+++ b/xpallets/support/src/lib.rs
@@ -14,4 +14,7 @@ pub use frame_support::fail;
 
 pub use self::macros::*;
 #[cfg(feature = "std")]
-pub use self::serde::{serde_hex, serde_num_str, serde_text, RpcBalance, RpcPrice, RpcU128};
+pub use self::serde::{
+    serde_hex, serde_num_str, serde_text, RpcBalance, RpcMiningWeight, RpcPrice, RpcU128,
+    RpcVoteWeight,
+};

--- a/xpallets/support/src/serde.rs
+++ b/xpallets/support/src/serde.rs
@@ -88,6 +88,12 @@ pub type RpcBalance<Balance> = RpcU128<Balance>;
 /// Price type of order when interacting with RPC.
 pub type RpcPrice<Price> = RpcU128<Price>;
 
+/// Weight type of mining when interacting with RPC.
+pub type RpcMiningWeight<Weight> = RpcU128<Weight>;
+
+/// Weight type of staking when interacting with RPC.
+pub type RpcVoteWeight<Weight> = RpcU128<Weight>;
+
 /// A helper struct for handling u128 serialization/deserialization of RPC.
 /// See https://github.com/polkadot-js/api/issues/2464 for details (shit!).
 #[derive(Eq, PartialEq, Copy, Clone, Debug, Serialize, Deserialize)]

--- a/xpallets/support/src/serde.rs
+++ b/xpallets/support/src/serde.rs
@@ -1,6 +1,6 @@
 // Copyright 2019-2020 ChainX Project Authors. Licensed under GPL-3.0.
 
-use std::{fmt, str};
+use std::{fmt::Display, str::FromStr};
 
 use serde::{de, ser, Deserialize, Serialize};
 
@@ -65,7 +65,7 @@ pub mod serde_num_str {
     pub fn serialize<S, T>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
-        T: fmt::Display,
+        T: Display,
     {
         serializer.serialize_str(&value.to_string())
     }
@@ -74,7 +74,7 @@ pub mod serde_num_str {
     pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>
     where
         D: de::Deserializer<'de>,
-        T: str::FromStr,
+        T: FromStr,
     {
         let data = String::deserialize(deserializer)?;
         data.parse::<T>()
@@ -97,9 +97,9 @@ pub type RpcVoteWeight<Weight> = RpcU128<Weight>;
 /// A helper struct for handling u128 serialization/deserialization of RPC.
 /// See https://github.com/polkadot-js/api/issues/2464 for details (shit!).
 #[derive(Eq, PartialEq, Copy, Clone, Debug, Serialize, Deserialize)]
-pub struct RpcU128<T: fmt::Display + str::FromStr>(#[serde(with = "self::serde_num_str")] T);
+pub struct RpcU128<T: Display + FromStr>(#[serde(with = "self::serde_num_str")] T);
 
-impl<T: fmt::Display + str::FromStr> From<T> for RpcU128<T> {
+impl<T: Display + FromStr> From<T> for RpcU128<T> {
     fn from(value: T) -> Self {
         RpcU128(value)
     }


### PR DESCRIPTION
Previously, the `Balance`, `Price` and `Weight` were serialized directly into u128 numbers
in chainx-org/ChainX#238, but polkadot.js could not parse them successfully.

Therefore, it is necessary to serialize `Balance`, `Price`, and `Weight` back to String.
Unlike before, the serialization conversion of `Balance` and `Price` only occurs at the RPC layer and does not involve the types in the pallet (because the `Weight` is an type alias of u128, so we use serde derive directly on the type to complete the serialization conversion).

Signed-off-by: koushiro <koushiro.cqx@gmail.com>