### PR TITLE
Bump up version to 2.0-alpha.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,14 +688,14 @@ dependencies = [
 
 [[package]]
 name = "chainx"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "chainx-cli",
 ]
 
 [[package]]
 name = "chainx-cli"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "chainx-executor",
  "chainx-primitives",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "chainx-executor"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "chainx-runtime",
  "frame-benchmarking",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "chainx-primitives"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "frame-system",
  "parity-scale-codec",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "chainx-rpc"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "chainx-primitives",
  "chainx-runtime",
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "chainx-runtime"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "chainx-primitives",
  "frame-benchmarking",
@@ -8812,7 +8812,7 @@ dependencies = [
 
 [[package]]
 name = "xp-assets-registrar"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "chainx-primitives",
  "frame-support",
@@ -8821,7 +8821,7 @@ dependencies = [
 
 [[package]]
 name = "xp-genesis-builder"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "chainx-primitives",
  "serde",
@@ -8830,7 +8830,7 @@ dependencies = [
 
 [[package]]
 name = "xp-io"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "hex",
  "parity-scale-codec",
@@ -8841,7 +8841,7 @@ dependencies = [
 
 [[package]]
 name = "xp-mining-common"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "chainx-primitives",
  "sp-arithmetic",
@@ -8851,7 +8851,7 @@ dependencies = [
 
 [[package]]
 name = "xp-mining-staking"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "chainx-primitives",
  "sp-runtime",
@@ -8861,7 +8861,7 @@ dependencies = [
 
 [[package]]
 name = "xp-protocol"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "chainx-primitives",
  "parity-scale-codec",
@@ -8871,7 +8871,7 @@ dependencies = [
 
 [[package]]
 name = "xp-runtime"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "hex",
  "parity-scale-codec",
@@ -8883,7 +8883,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-assets"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "bitflags",
  "chainx-primitives",
@@ -8906,7 +8906,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-assets-registrar"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "chainx-primitives",
  "frame-benchmarking",
@@ -8926,7 +8926,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-assets-rpc"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -8941,7 +8941,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-assets-rpc-runtime-api"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "chainx-primitives",
  "parity-scale-codec",
@@ -8952,7 +8952,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-dex-spot"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "chainx-primitives",
  "env_logger",
@@ -8975,7 +8975,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-dex-spot-rpc"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -8991,7 +8991,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-dex-spot-rpc-runtime-api"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9001,7 +9001,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-gateway-bitcoin"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "bs58",
  "chainx-primitives",
@@ -9033,7 +9033,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-gateway-common"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "bs58",
  "chainx-primitives",
@@ -9062,7 +9062,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-gateway-common-rpc"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "hex",
  "jsonrpc-core",
@@ -9078,7 +9078,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-gateway-common-rpc-runtime-api"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "chainx-primitives",
  "parity-scale-codec",
@@ -9092,7 +9092,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-gateway-records"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "chainx-primitives",
  "frame-benchmarking",
@@ -9115,7 +9115,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-gateway-records-rpc"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -9131,7 +9131,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-gateway-records-rpc-runtime-api"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "chainx-primitives",
  "parity-scale-codec",
@@ -9143,7 +9143,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-genesis-builder"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "chainx-primitives",
  "frame-support",
@@ -9163,7 +9163,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-mining-asset"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "chainx-primitives",
  "env_logger",
@@ -9191,7 +9191,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-mining-asset-rpc"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -9206,7 +9206,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-mining-asset-rpc-runtime-api"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "chainx-primitives",
  "parity-scale-codec",
@@ -9217,7 +9217,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-mining-staking"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "chainx-primitives",
  "env_logger",
@@ -9245,7 +9245,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-mining-staking-rpc"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -9260,7 +9260,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-mining-staking-rpc-runtime-api"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9270,7 +9270,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-support"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "frame-support",
  "hex",
@@ -9282,7 +9282,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-system"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainx"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 description = "Fully Decentralized Interchain Crypto Asset Management on Polkadot"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainx-cli"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 description = "Implementation of protocol https://chainx.org in Rust based on the Substrate framework."
 edition = "2018"

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainx-executor"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainx-primitives"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/primitives/assets-registrar/Cargo.toml
+++ b/primitives/assets-registrar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xp-assets-registrar"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/primitives/genesis-builder/Cargo.toml
+++ b/primitives/genesis-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xp-genesis-builder"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/primitives/io/Cargo.toml
+++ b/primitives/io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xp-io"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/primitives/mining/common/Cargo.toml
+++ b/primitives/mining/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xp-mining-common"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/primitives/mining/staking/Cargo.toml
+++ b/primitives/mining/staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xp-mining-staking"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/primitives/protocol/Cargo.toml
+++ b/primitives/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xp-protocol"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/primitives/runtime/Cargo.toml
+++ b/primitives/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xp-runtime"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainx-rpc"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainx-runtime"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/assets-registrar/Cargo.toml
+++ b/xpallets/assets-registrar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-assets-registrar"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/assets/Cargo.toml
+++ b/xpallets/assets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-assets"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/assets/rpc/Cargo.toml
+++ b/xpallets/assets/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-assets-rpc"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/assets/rpc/runtime-api/Cargo.toml
+++ b/xpallets/assets/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-assets-rpc-runtime-api"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/dex/spot/Cargo.toml
+++ b/xpallets/dex/spot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-dex-spot"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/dex/spot/rpc/Cargo.toml
+++ b/xpallets/dex/spot/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-dex-spot-rpc"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/dex/spot/rpc/runtime-api/Cargo.toml
+++ b/xpallets/dex/spot/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-dex-spot-rpc-runtime-api"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/gateway/bitcoin/Cargo.toml
+++ b/xpallets/gateway/bitcoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-gateway-bitcoin"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/gateway/common/Cargo.toml
+++ b/xpallets/gateway/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-gateway-common"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/gateway/common/rpc/Cargo.toml
+++ b/xpallets/gateway/common/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-gateway-common-rpc"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/gateway/common/rpc/runtime-api/Cargo.toml
+++ b/xpallets/gateway/common/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-gateway-common-rpc-runtime-api"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/gateway/records/Cargo.toml
+++ b/xpallets/gateway/records/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-gateway-records"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/gateway/records/rpc/Cargo.toml
+++ b/xpallets/gateway/records/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-gateway-records-rpc"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/gateway/records/rpc/runtime-api/Cargo.toml
+++ b/xpallets/gateway/records/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-gateway-records-rpc-runtime-api"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/genesis-builder/Cargo.toml
+++ b/xpallets/genesis-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-genesis-builder"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/mining/asset/Cargo.toml
+++ b/xpallets/mining/asset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-mining-asset"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/mining/asset/rpc/Cargo.toml
+++ b/xpallets/mining/asset/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-mining-asset-rpc"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/mining/asset/rpc/runtime-api/Cargo.toml
+++ b/xpallets/mining/asset/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-mining-asset-rpc-runtime-api"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/mining/staking/Cargo.toml
+++ b/xpallets/mining/staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-mining-staking"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/mining/staking/rpc/Cargo.toml
+++ b/xpallets/mining/staking/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-mining-staking-rpc"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/mining/staking/rpc/runtime-api/Cargo.toml
+++ b/xpallets/mining/staking/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-mining-staking-rpc-runtime-api"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/support/Cargo.toml
+++ b/xpallets/support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-support"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/system/Cargo.toml
+++ b/xpallets/system/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-system"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = ["The ChainX Authors"]
 edition = "2018"
 


### PR DESCRIPTION
Changelog:

- Serialize `u128` as String in RPC as `u128` can not be decoded correctly on the JS side. #307
- Fix the excutable name. #306