### PR TITLE
Remove society and recovery module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,10 +837,8 @@ dependencies = [
  "pallet-multisig",
  "pallet-offences",
  "pallet-randomness-collective-flip",
- "pallet-recovery",
  "pallet-scheduler",
  "pallet-session",
- "pallet-society",
  "pallet-sudo",
  "pallet-timestamp",
  "pallet-transaction-payment",
@@ -4218,22 +4216,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-recovery"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "639979e3afb0365bf8669e83f20522798268a837d976936d450d5b233d5405fc"
-dependencies = [
- "enumflags2",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "serde",
- "sp-io",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
 name = "pallet-scheduler"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4268,21 +4250,6 @@ dependencies = [
  "sp-staking",
  "sp-std",
  "sp-trie",
-]
-
-[[package]]
-name = "pallet-society"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a9097dccf372915661c637d0f3839663cd8d11b7749fa70323f6060cff69fa"
-dependencies = [
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "rand_chacha 0.2.2",
- "serde",
- "sp-runtime",
- "sp-std",
 ]
 
 [[package]]

--- a/cli/src/chain_spec.rs
+++ b/cli/src/chain_spec.rs
@@ -27,8 +27,8 @@ use chainx_runtime::{
 };
 use chainx_runtime::{
     AuthorityDiscoveryConfig, BalancesConfig, CouncilConfig, DemocracyConfig, ElectionsConfig,
-    GenesisConfig, GrandpaConfig, ImOnlineConfig, IndicesConfig, SessionConfig, SocietyConfig,
-    SudoConfig, SystemConfig, TechnicalCommitteeConfig, XAssetsConfig, XAssetsRegistrarConfig,
+    GenesisConfig, GrandpaConfig, ImOnlineConfig, IndicesConfig, SessionConfig, SudoConfig,
+    SystemConfig, TechnicalCommitteeConfig, XAssetsConfig, XAssetsRegistrarConfig,
     XGatewayBitcoinConfig, XGatewayCommonConfig, XGenesisBuilderConfig, XMiningAssetConfig,
     XSpotConfig, XStakingConfig, XSystemConfig,
 };
@@ -662,8 +662,6 @@ fn build_genesis(
         .cloned()
         .collect::<Vec<_>>();
 
-    let society_members = tech_comm_members.clone();
-
     // PCX only reserves the native asset id in assets module,
     // the actual native fund management is handled by pallet_balances.
     let mut assets_endowed = endowed;
@@ -726,11 +724,6 @@ fn build_genesis(
         }),
         pallet_balances: Some(BalancesConfig { balances }),
         pallet_indices: Some(IndicesConfig { indices: vec![] }),
-        pallet_society: Some(SocietyConfig {
-            members: society_members,
-            pot: 0,
-            max_members: 999,
-        }),
         pallet_sudo: Some(SudoConfig { key: root_key }),
         xpallet_system: Some(XSystemConfig {
             network_props: NetworkType::Testnet,

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -49,10 +49,8 @@ pallet-membership = { version = "2.0.0", default-features = false }
 pallet-multisig = { version = "2.0.0", default-features = false }
 pallet-offences = { version = "2.0.0", default-features = false }
 pallet-randomness-collective-flip = { version = "2.0.0", default-features = false }
-pallet-recovery = { version = "2.0.0", default-features = false }
 pallet-scheduler = { version = "2.0.0", default-features = false }
 pallet-session = { version = "2.0.0", default-features = false, features = ["historical"] }
-pallet-society = { version = "2.0.0", default-features = false }
 pallet-sudo = { version = "2.0.0", default-features = false }
 pallet-timestamp = { version = "2.0.0", default-features = false }
 pallet-transaction-payment = { version = "2.0.0", default-features = false }
@@ -136,10 +134,8 @@ std = [
     "pallet-multisig/std",
     "pallet-offences/std",
     "pallet-randomness-collective-flip/std",
-    "pallet-recovery/std",
     "pallet-scheduler/std",
     "pallet-session/std",
-    "pallet-society/std",
     "pallet-sudo/std",
     "pallet-timestamp/std",
     "pallet-transaction-payment/std",
@@ -181,7 +177,6 @@ runtime-benchmarks = [
     "sp-runtime/runtime-benchmarks",
     "pallet-balances/runtime-benchmarks",
     "pallet-collective/runtime-benchmarks",
-    "pallet-society/runtime-benchmarks",
     "xpallet-assets/runtime-benchmarks",
     "xpallet-assets-registrar/runtime-benchmarks",
     "xpallet-dex-spot/runtime-benchmarks",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -762,52 +762,6 @@ impl pallet_identity::Trait for Runtime {
     type WeightInfo = weights::pallet_identity::WeightInfo;
 }
 
-parameter_types! {
-    pub const ConfigDepositBase: Balance = 5 * DOLLARS;
-    pub const FriendDepositFactor: Balance = 50 * CENTS;
-    pub const MaxFriends: u16 = 9;
-    pub const RecoveryDeposit: Balance = 5 * DOLLARS;
-}
-
-impl pallet_recovery::Trait for Runtime {
-    type Event = Event;
-    type Call = Call;
-    type Currency = Balances;
-    type ConfigDepositBase = ConfigDepositBase;
-    type FriendDepositFactor = FriendDepositFactor;
-    type MaxFriends = MaxFriends;
-    type RecoveryDeposit = RecoveryDeposit;
-}
-
-parameter_types! {
-    pub const CandidateDeposit: Balance = 10 * DOLLARS;
-    pub const WrongSideDeduction: Balance = 2 * DOLLARS;
-    pub const MaxStrikes: u32 = 10;
-    pub const RotationPeriod: BlockNumber = 80 * HOURS;
-    pub const PeriodSpend: Balance = 500 * DOLLARS;
-    pub const MaxLockDuration: BlockNumber = 36 * 30 * DAYS;
-    pub const ChallengePeriod: BlockNumber = 7 * DAYS;
-    pub const SocietyModuleId: ModuleId = ModuleId(*b"py/socie");
-}
-
-impl pallet_society::Trait for Runtime {
-    type Event = Event;
-    type ModuleId = SocietyModuleId;
-    type Currency = Balances;
-    type Randomness = RandomnessCollectiveFlip;
-    type CandidateDeposit = CandidateDeposit;
-    type WrongSideDeduction = WrongSideDeduction;
-    type MaxStrikes = MaxStrikes;
-    type PeriodSpend = PeriodSpend;
-    type MembershipChanged = ();
-    type RotationPeriod = RotationPeriod;
-    type MaxLockDuration = MaxLockDuration;
-    type FounderSetOrigin =
-        pallet_collective::EnsureProportionMoreThan<_1, _2, AccountId, CouncilCollective>;
-    type SuspensionJudgementOrigin = pallet_society::EnsureFounder<Runtime>;
-    type ChallengePeriod = ChallengePeriod;
-}
-
 ///////////////////////////////////////////
 // orml
 ///////////////////////////////////////////
@@ -975,8 +929,6 @@ construct_runtime!(
         Treasury: pallet_treasury::{Module, Call, Storage, Config, Event<T>},
 
         Identity: pallet_identity::{Module, Call, Storage, Event<T>},
-        Society: pallet_society::{Module, Call, Storage, Event<T>, Config<T>},
-        Recovery: pallet_recovery::{Module, Call, Storage, Event<T>},
 
         Utility: pallet_utility::{Module, Call, Event},
         Multisig: pallet_multisig::{Module, Call, Storage, Event<T>},

--- a/xpallets/mining/staking/src/election.rs
+++ b/xpallets/mining/staking/src/election.rs
@@ -15,8 +15,8 @@ impl<T: Trait> Module<T> {
         // Set staking information for new era.
         let maybe_new_validators = Self::select_and_update_validators(current_era);
         debug!(
-            "[new_era]start_session_index:{:?}, maybe_new_validators:{:?}",
-            start_session_index, maybe_new_validators
+            "[new_era]era_index:{}, start_session_index:{}, maybe_new_validators:{:?}",
+            current_era, start_session_index, maybe_new_validators
         );
 
         maybe_new_validators


### PR DESCRIPTION
These modules are only enabled on Kusama, not Polkadot. Better to not include them by default, and the community can decide whether to add these features in the future by governance.