### PR TITLE
Introduce preliminary rpc primitives for unified RPC error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8870,6 +8870,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "xp-rpc"
+version = "2.0.0-alpha.3"
+dependencies = [
+ "jsonrpc-core",
+]
+
+[[package]]
 name = "xp-runtime"
 version = "2.0.0-alpha.3"
 dependencies = [
@@ -8935,6 +8942,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-runtime",
+ "xp-rpc",
  "xpallet-assets-rpc-runtime-api",
  "xpallet-support",
 ]
@@ -8985,6 +8993,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-runtime",
+ "xp-rpc",
  "xpallet-dex-spot-rpc-runtime-api",
  "xpallet-support",
 ]
@@ -9072,6 +9081,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-runtime",
+ "xp-rpc",
  "xpallet-gateway-common-rpc-runtime-api",
  "xpallet-support",
 ]
@@ -9125,6 +9135,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-runtime",
+ "xp-rpc",
  "xpallet-gateway-records-rpc-runtime-api",
  "xpallet-support",
 ]
@@ -9200,6 +9211,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-runtime",
+ "xp-rpc",
  "xpallet-mining-asset-rpc-runtime-api",
  "xpallet-support",
 ]
@@ -9254,6 +9266,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-runtime",
+ "xp-rpc",
  "xpallet-mining-staking-rpc-runtime-api",
  "xpallet-support",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "primitives/mining/common",
     "primitives/mining/staking",
     "primitives/protocol",
+    "primitives/rpc",
     "primitives/runtime",
     "rpc",
     "runtime",

--- a/primitives/rpc/Cargo.toml
+++ b/primitives/rpc/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "xp-rpc"
+version = "2.0.0-alpha.3"
+authors = ["The ChainX Authors"]
+edition = "2018"
+
+[dependencies]
+jsonrpc-core = "15.0.0"

--- a/primitives/rpc/src/lib.rs
+++ b/primitives/rpc/src/lib.rs
@@ -20,18 +20,11 @@ pub fn runtime_error_into_rpc_err(err: impl Debug) -> Error {
     }
 }
 
+/// Converts a hex decode error into an RPC error.
 pub fn hex_decode_error_into_rpc_err(err: impl Debug) -> Error {
     Error {
         code: ErrorCode::ServerError(HEX_DECODE_ERROR),
         message: "Failed to decode hex".into(),
-        data: Some(format!("{:?}", err).into()),
-    }
-}
-
-pub fn new_runtime_error(message: String, err: impl Debug) -> Error {
-    Error {
-        code: ErrorCode::ServerError(RUNTIME_ERROR),
-        message,
         data: Some(format!("{:?}", err).into()),
     }
 }

--- a/primitives/rpc/src/lib.rs
+++ b/primitives/rpc/src/lib.rs
@@ -13,7 +13,7 @@ const RUNTIME_TRUSTEE_ERROR: i64 = RUNTIME_ERROR + 100;
 /// Decode the generic trustee info failed.
 ///
 /// TODO: these pallet-specific errors should be moved to its own rpc module
-/// then there are many of them.
+/// when there are many of them.
 pub const RUNTIME_TRUSTEE_DECODE_ERROR: i64 = RUNTIME_TRUSTEE_ERROR + 1;
 
 /// The trustees are inexistent.

--- a/primitives/rpc/src/lib.rs
+++ b/primitives/rpc/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright 2019-2020 ChainX Project Authors. Licensed under GPL-3.0.
+
 use std::fmt::Debug;
 
 pub use jsonrpc_core::{Error, ErrorCode, Result};
@@ -6,16 +8,19 @@ pub use jsonrpc_core::{Error, ErrorCode, Result};
 pub const RUNTIME_ERROR: i64 = 1;
 
 /// The call related to trustee to runtime failed.
-pub const RUNTIME_TRUSTEE_ERROR: i64 = RUNTIME_ERROR + 100;
+const RUNTIME_TRUSTEE_ERROR: i64 = RUNTIME_ERROR + 100;
 
 /// Decode the generic trustee info failed.
+///
+/// TODO: these pallet-specific errors should be moved to its own rpc module
+/// then there are many of them.
 pub const RUNTIME_TRUSTEE_DECODE_ERROR: i64 = RUNTIME_TRUSTEE_ERROR + 1;
 
 /// The trustees are inexistent.
 pub const RUNTIME_TRUSTEE_INEXISTENT_ERROR: i64 = RUNTIME_TRUSTEE_ERROR + 2;
 
 /// The transaction was not decodable.
-pub const DECODE_ERROR: i64 = 1000;
+pub const DECODE_ERROR: i64 = 10000;
 
 /// The bytes failed to be decoded as hex.
 pub const DECODE_HEX_ERROR: i64 = DECODE_ERROR + 1;
@@ -39,7 +44,7 @@ pub fn trustee_decode_error_into_rpc_err(err: impl Debug) -> Error {
 }
 
 /// Converts a trustee runtime trap into an RPC error.
-pub fn trustee_inexistent_error_into_rpc_err() -> Error {
+pub fn trustee_inexistent_rpc_err() -> Error {
     Error {
         code: ErrorCode::ServerError(RUNTIME_TRUSTEE_INEXISTENT_ERROR),
         message: "Trustee does not exist".into(),

--- a/primitives/rpc/src/lib.rs
+++ b/primitives/rpc/src/lib.rs
@@ -1,15 +1,15 @@
 use std::fmt::Debug;
 
-use jsonrpc_core::{Error, ErrorCode};
+pub use jsonrpc_core::{Error, ErrorCode, Result};
 
 /// The call to runtime failed.
 pub const RUNTIME_ERROR: i64 = 1;
 
 /// The transaction was not decodable.
-pub const DECODE_ERROR: i64 = 2;
+pub const DECODE_ERROR: i64 = 100;
 
 /// The bytes failed to be decoded as hex.
-pub const HEX_DECODE_ERROR: i64 = 3;
+pub const HEX_DECODE_ERROR: i64 = DECODE_ERROR + 1;
 
 /// Converts a runtime trap into an RPC error.
 pub fn runtime_error_into_rpc_err(err: impl Debug) -> Error {

--- a/primitives/rpc/src/lib.rs
+++ b/primitives/rpc/src/lib.rs
@@ -1,0 +1,37 @@
+use std::fmt::Debug;
+
+use jsonrpc_core::{Error, ErrorCode};
+
+/// The call to runtime failed.
+pub const RUNTIME_ERROR: i64 = 1;
+
+/// The transaction was not decodable.
+pub const DECODE_ERROR: i64 = 2;
+
+/// The bytes failed to be decoded as hex.
+pub const HEX_DECODE_ERROR: i64 = 3;
+
+/// Converts a runtime trap into an RPC error.
+pub fn runtime_error_into_rpc_err(err: impl Debug) -> Error {
+    Error {
+        code: ErrorCode::ServerError(RUNTIME_ERROR),
+        message: "Runtime trapped".into(),
+        data: Some(format!("{:?}", err).into()),
+    }
+}
+
+pub fn hex_decode_error_into_rpc_err(err: impl Debug) -> Error {
+    Error {
+        code: ErrorCode::ServerError(HEX_DECODE_ERROR),
+        message: "Failed to decode hex".into(),
+        data: Some(format!("{:?}", err).into()),
+    }
+}
+
+pub fn new_runtime_error(message: String, err: impl Debug) -> Error {
+    Error {
+        code: ErrorCode::ServerError(RUNTIME_ERROR),
+        message,
+        data: Some(format!("{:?}", err).into()),
+    }
+}

--- a/primitives/rpc/src/lib.rs
+++ b/primitives/rpc/src/lib.rs
@@ -5,11 +5,20 @@ pub use jsonrpc_core::{Error, ErrorCode, Result};
 /// The call to runtime failed.
 pub const RUNTIME_ERROR: i64 = 1;
 
+/// The call related to trustee to runtime failed.
+pub const RUNTIME_TRUSTEE_ERROR: i64 = RUNTIME_ERROR + 100;
+
+/// Decode the generic trustee info failed.
+pub const RUNTIME_TRUSTEE_DECODE_ERROR: i64 = RUNTIME_TRUSTEE_ERROR + 1;
+
+/// The trustees are inexistent.
+pub const RUNTIME_TRUSTEE_INEXISTENT_ERROR: i64 = RUNTIME_TRUSTEE_ERROR + 2;
+
 /// The transaction was not decodable.
-pub const DECODE_ERROR: i64 = 100;
+pub const DECODE_ERROR: i64 = 1000;
 
 /// The bytes failed to be decoded as hex.
-pub const HEX_DECODE_ERROR: i64 = DECODE_ERROR + 1;
+pub const DECODE_HEX_ERROR: i64 = DECODE_ERROR + 1;
 
 /// Converts a runtime trap into an RPC error.
 pub fn runtime_error_into_rpc_err(err: impl Debug) -> Error {
@@ -20,10 +29,28 @@ pub fn runtime_error_into_rpc_err(err: impl Debug) -> Error {
     }
 }
 
+/// Converts a trustee runtime trap into an RPC error.
+pub fn trustee_decode_error_into_rpc_err(err: impl Debug) -> Error {
+    Error {
+        code: ErrorCode::ServerError(RUNTIME_TRUSTEE_DECODE_ERROR),
+        message: "Can not decode generic trustee session info".into(),
+        data: Some(format!("{:?}", err).into()),
+    }
+}
+
+/// Converts a trustee runtime trap into an RPC error.
+pub fn trustee_inexistent_error_into_rpc_err() -> Error {
+    Error {
+        code: ErrorCode::ServerError(RUNTIME_TRUSTEE_INEXISTENT_ERROR),
+        message: "Trustee does not exist".into(),
+        data: None,
+    }
+}
+
 /// Converts a hex decode error into an RPC error.
 pub fn hex_decode_error_into_rpc_err(err: impl Debug) -> Error {
     Error {
-        code: ErrorCode::ServerError(HEX_DECODE_ERROR),
+        code: ErrorCode::ServerError(DECODE_HEX_ERROR),
         message: "Failed to decode hex".into(),
         data: Some(format!("{:?}", err).into()),
     }

--- a/scripts/chainx-js/res/chainx_rpc.json
+++ b/scripts/chainx-js/res/chainx_rpc.json
@@ -138,7 +138,7 @@
                     "isOptional": true
                 }
             ],
-            "type": "()"
+            "type": "bool"
         },
         "trusteeMultisigs": {
             "description": "Return the trustee multisig address for all chain.",

--- a/xpallets/assets/rpc/Cargo.toml
+++ b/xpallets/assets/rpc/Cargo.toml
@@ -18,6 +18,9 @@ sp-api = "2.0.0"
 sp-blockchain = "2.0.0"
 sp-runtime = "2.0.0"
 
+# ChainX primitives
+xp-rpc = { path = "../../../primitives/rpc" }
+
 # ChainX pallets
 xpallet-support = { path = "../../support" }
 

--- a/xpallets/assets/rpc/src/lib.rs
+++ b/xpallets/assets/rpc/src/lib.rs
@@ -1,12 +1,12 @@
 // Copyright 2019-2020 ChainX Project Authors. Licensed under GPL-3.0.
 
 use std::collections::BTreeMap;
-use std::fmt::{Debug, Display};
+use std::fmt::Display;
 use std::str::FromStr;
 use std::sync::Arc;
 
 use codec::Codec;
-use jsonrpc_core::{Error, ErrorCode, Result};
+use jsonrpc_core::Result;
 use jsonrpc_derive::rpc;
 
 use sp_blockchain::HeaderBackend;
@@ -89,7 +89,7 @@ where
                     })
                     .collect::<BTreeMap<_, _>>()
             })
-            .map_err(runtime_error_into_rpc_err)
+            .map_err(xp_rpc::runtime_error_into_rpc_err)
     }
 
     fn assets(
@@ -126,16 +126,6 @@ where
                     })
                     .collect()
             })
-            .map_err(runtime_error_into_rpc_err)
-    }
-}
-
-const RUNTIME_ERROR: i64 = 1;
-/// Converts a runtime trap into an RPC error.
-fn runtime_error_into_rpc_err(err: impl Debug) -> Error {
-    Error {
-        code: ErrorCode::ServerError(RUNTIME_ERROR),
-        message: "Runtime trapped".into(),
-        data: Some(format!("{:?}", err).into()),
+            .map_err(xp_rpc::runtime_error_into_rpc_err)
     }
 }

--- a/xpallets/assets/rpc/src/lib.rs
+++ b/xpallets/assets/rpc/src/lib.rs
@@ -6,7 +6,6 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use codec::Codec;
-use jsonrpc_core::Result;
 use jsonrpc_derive::rpc;
 
 use sp_blockchain::HeaderBackend;
@@ -14,6 +13,8 @@ use sp_runtime::{
     generic::BlockId,
     traits::{Block as BlockT, Zero},
 };
+
+use xp_rpc::{runtime_error_into_rpc_err, Result};
 
 use xpallet_support::RpcBalance;
 
@@ -29,7 +30,7 @@ pub struct Assets<C, B> {
 impl<C, B> Assets<C, B> {
     /// Create new `Contracts` with the given reference to the client.
     pub fn new(client: Arc<C>) -> Self {
-        Assets {
+        Self {
             client,
             _marker: Default::default(),
         }
@@ -89,7 +90,7 @@ where
                     })
                     .collect::<BTreeMap<_, _>>()
             })
-            .map_err(xp_rpc::runtime_error_into_rpc_err)
+            .map_err(runtime_error_into_rpc_err)
     }
 
     fn assets(
@@ -126,6 +127,6 @@ where
                     })
                     .collect()
             })
-            .map_err(xp_rpc::runtime_error_into_rpc_err)
+            .map_err(runtime_error_into_rpc_err)
     }
 }

--- a/xpallets/assets/rpc/src/lib.rs
+++ b/xpallets/assets/rpc/src/lib.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use codec::Codec;
 use jsonrpc_derive::rpc;
 
+use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::{
     generic::BlockId,
@@ -61,9 +62,7 @@ where
 impl<C, Block, AccountId, Balance> XAssetsApi<<Block as BlockT>::Hash, AccountId, Balance>
     for Assets<C, Block>
 where
-    C: sp_api::ProvideRuntimeApi<Block>,
-    C: HeaderBackend<Block>,
-    C: Send + Sync + 'static,
+    C: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
     C::Api: XAssetsRuntimeApi<Block, AccountId, Balance>,
     Block: BlockT,
     AccountId: Clone + Display + Codec,

--- a/xpallets/dex/spot/rpc/Cargo.toml
+++ b/xpallets/dex/spot/rpc/Cargo.toml
@@ -19,6 +19,9 @@ sp-api = "2.0.0"
 sp-blockchain = "2.0.0"
 sp-runtime = "2.0.0"
 
+# ChainX primitives
+xp-rpc = { path = "../../../../primitives/rpc" }
+
 # ChainX pallets
 xpallet-support = { path = "../../../support" }
 

--- a/xpallets/dex/spot/rpc/src/lib.rs
+++ b/xpallets/dex/spot/rpc/src/lib.rs
@@ -9,13 +9,14 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use codec::Codec;
-use jsonrpc_core::Result;
 use jsonrpc_derive::rpc;
 use serde::{Deserialize, Serialize};
 
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::{generic::BlockId, traits::Block as BlockT};
+
+use xp_rpc::{runtime_error_into_rpc_err, Result};
 
 use xpallet_support::{RpcBalance, RpcPrice};
 
@@ -125,7 +126,7 @@ where
                     )
                     .collect::<Vec<_>>()
             })
-            .map_err(xp_rpc::runtime_error_into_rpc_err)?)
+            .map_err(runtime_error_into_rpc_err)?)
     }
 
     fn orders(
@@ -174,7 +175,7 @@ where
                     })
                     .collect::<Vec<_>>()
             })
-            .map_err(xp_rpc::runtime_error_into_rpc_err)?;
+            .map_err(runtime_error_into_rpc_err)?;
         Ok(Page {
             page_index,
             page_size,
@@ -205,7 +206,7 @@ where
                 Ok(Some(Depth { asks, bids }))
             }
             Ok(None) => Ok(None),
-            Err(err) => Err(xp_rpc::runtime_error_into_rpc_err(err)),
+            Err(err) => Err(runtime_error_into_rpc_err(err)),
         }
     }
 }

--- a/xpallets/gateway/common/rpc/Cargo.toml
+++ b/xpallets/gateway/common/rpc/Cargo.toml
@@ -19,6 +19,9 @@ sp-api = "2.0.0"
 sp-blockchain = "2.0.0"
 sp-runtime = "2.0.0"
 
+# ChainX primitives
+xp-rpc = { path = "../../../../primitives/rpc" }
+
 # ChainX pallets
 xpallet-support = { path = "../../../support" }
 

--- a/xpallets/gateway/common/rpc/src/lib.rs
+++ b/xpallets/gateway/common/rpc/src/lib.rs
@@ -9,14 +9,16 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use codec::Codec;
-use jsonrpc_core::{Error as RpcError, ErrorCode, Result};
 use jsonrpc_derive::rpc;
 
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::{generic::BlockId, traits::Block as BlockT};
 
-use xp_rpc::runtime_error_into_rpc_err;
+use xp_rpc::{
+    hex_decode_error_into_rpc_err, runtime_error_into_rpc_err, Error as RpcError, ErrorCode,
+    Result, RUNTIME_ERROR,
+};
 
 use xpallet_support::RpcBalance;
 
@@ -126,7 +128,7 @@ where
             .trustee_properties(&at, chain, who)
             .map_err(runtime_error_into_rpc_err)?
             .ok_or(RpcError {
-                code: ErrorCode::ServerError(xp_rpc::RUNTIME_ERROR + 1),
+                code: ErrorCode::ServerError(RUNTIME_ERROR + 1),
                 message: "Not exist".into(),
                 data: None,
             })?;
@@ -146,7 +148,7 @@ where
             .trustee_session_info(&at, chain)
             .map_err(runtime_error_into_rpc_err)?
             .ok_or(RpcError {
-                code: ErrorCode::ServerError(xp_rpc::RUNTIME_ERROR + 1),
+                code: ErrorCode::ServerError(RUNTIME_ERROR + 1),
                 message: "Not exist".into(),
                 data: None,
             })?;
@@ -244,7 +246,7 @@ where
     ) -> Result<bool> {
         let value: Balance = Balance::from(value);
         let addr = if addr.starts_with("0x") {
-            hex::decode(&addr[2..]).map_err(xp_rpc::hex_decode_error_into_rpc_err)?
+            hex::decode(&addr[2..]).map_err(hex_decode_error_into_rpc_err)?
         } else {
             hex::decode(&addr).unwrap_or_else(|_| addr.into_bytes())
         };
@@ -303,7 +305,7 @@ where
 /// Converts a runtime trap into an RPC error.
 fn trustee_error_into_rpc_err(err: impl Debug) -> RpcError {
     RpcError {
-        code: ErrorCode::ServerError(xp_rpc::RUNTIME_ERROR + 2),
+        code: ErrorCode::ServerError(RUNTIME_ERROR + 2),
         message: "Can not decode generic trustee session info".into(),
         data: Some(format!("{:?}", err).into()),
     }

--- a/xpallets/gateway/common/rpc/src/lib.rs
+++ b/xpallets/gateway/common/rpc/src/lib.rs
@@ -17,7 +17,7 @@ use sp_runtime::{generic::BlockId, traits::Block as BlockT};
 
 use xp_rpc::{
     hex_decode_error_into_rpc_err, runtime_error_into_rpc_err, trustee_decode_error_into_rpc_err,
-    trustee_inexistent_error_into_rpc_err, Result,
+    trustee_inexistent_rpc_err, Result,
 };
 
 use xpallet_support::RpcBalance;
@@ -127,7 +127,7 @@ where
         let result = api
             .trustee_properties(&at, chain, who)
             .map_err(runtime_error_into_rpc_err)?
-            .ok_or(trustee_inexistent_error_into_rpc_err())?;
+            .ok_or(trustee_inexistent_rpc_err())?;
 
         Ok(result)
     }
@@ -143,7 +143,7 @@ where
         let result = api
             .trustee_session_info(&at, chain)
             .map_err(runtime_error_into_rpc_err)?
-            .ok_or(trustee_inexistent_error_into_rpc_err())?;
+            .ok_or(trustee_inexistent_rpc_err())?;
 
         Ok(result)
     }

--- a/xpallets/gateway/records/rpc/Cargo.toml
+++ b/xpallets/gateway/records/rpc/Cargo.toml
@@ -19,6 +19,9 @@ sp-api = "2.0.0"
 sp-blockchain = "2.0.0"
 sp-runtime = "2.0.0"
 
+# ChainX primitives
+xp-rpc = { path = "../../../../primitives/rpc" }
+
 # ChainX pallets
 xpallet-support = { path = "../../../support" }
 

--- a/xpallets/gateway/records/rpc/src/lib.rs
+++ b/xpallets/gateway/records/rpc/src/lib.rs
@@ -6,14 +6,13 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use codec::Codec;
-use jsonrpc_core::Result;
 use jsonrpc_derive::rpc;
 use serde::{Deserialize, Serialize};
 
 use sp_blockchain::HeaderBackend;
 use sp_runtime::{generic::BlockId, traits::Block as BlockT};
 
-use xp_rpc::runtime_error_into_rpc_err;
+use xp_rpc::{runtime_error_into_rpc_err, Result};
 
 use xpallet_gateway_records_rpc_runtime_api::{
     AssetId, Chain, Withdrawal, WithdrawalRecordId, WithdrawalState,
@@ -29,7 +28,7 @@ pub struct XGatewayRecords<C, B> {
 impl<C, B> XGatewayRecords<C, B> {
     /// Create new `Contracts` with the given reference to the client.
     pub fn new(client: Arc<C>) -> Self {
-        XGatewayRecords {
+        Self {
             client,
             _marker: Default::default(),
         }
@@ -150,7 +149,7 @@ impl<AccountId, Balance: Display + FromStr, BlockNumber>
     for RpcWithdrawalRecord<AccountId, Balance, BlockNumber>
 {
     fn from(record: Withdrawal<AccountId, Balance, BlockNumber>) -> Self {
-        RpcWithdrawalRecord {
+        Self {
             asset_id: record.asset_id,
             applicant: record.applicant,
             balance: record.balance,

--- a/xpallets/gateway/records/rpc/src/lib.rs
+++ b/xpallets/gateway/records/rpc/src/lib.rs
@@ -1,17 +1,19 @@
 // Copyright 2019-2020 ChainX Project Authors. Licensed under GPL-3.0.
 
 use std::collections::BTreeMap;
-use std::fmt::{Debug, Display};
+use std::fmt::Display;
 use std::str::FromStr;
 use std::sync::Arc;
 
 use codec::Codec;
-use jsonrpc_core::{Error, ErrorCode, Result};
+use jsonrpc_core::Result;
 use jsonrpc_derive::rpc;
 use serde::{Deserialize, Serialize};
 
 use sp_blockchain::HeaderBackend;
 use sp_runtime::{generic::BlockId, traits::Block as BlockT};
+
+use xp_rpc::runtime_error_into_rpc_err;
 
 use xpallet_gateway_records_rpc_runtime_api::{
     AssetId, Chain, Withdrawal, WithdrawalRecordId, WithdrawalState,
@@ -157,15 +159,5 @@ impl<AccountId, Balance: Display + FromStr, BlockNumber>
             height: record.height,
             state: record.state,
         }
-    }
-}
-
-const RUNTIME_ERROR: i64 = 1;
-/// Converts a runtime trap into an RPC error.
-fn runtime_error_into_rpc_err(err: impl Debug) -> Error {
-    Error {
-        code: ErrorCode::ServerError(RUNTIME_ERROR),
-        message: "Runtime trapped".into(),
-        data: Some(format!("{:?}", err).into()),
     }
 }

--- a/xpallets/gateway/records/rpc/src/lib.rs
+++ b/xpallets/gateway/records/rpc/src/lib.rs
@@ -9,6 +9,7 @@ use codec::Codec;
 use jsonrpc_derive::rpc;
 use serde::{Deserialize, Serialize};
 
+use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::{generic::BlockId, traits::Block as BlockT};
 
@@ -68,9 +69,7 @@ impl<C, Block, AccountId, Balance, BlockNumber>
     XGatewayRecordsApi<<Block as BlockT>::Hash, AccountId, Balance, BlockNumber>
     for XGatewayRecords<C, Block>
 where
-    C: sp_api::ProvideRuntimeApi<Block>,
-    C: HeaderBackend<Block>,
-    C: Send + Sync + 'static,
+    C: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
     C::Api: GatewayRecordsRuntimeApi<Block, AccountId, Balance, BlockNumber>,
     Block: BlockT,
     AccountId: Clone + Display + FromStr + Codec,

--- a/xpallets/mining/asset/rpc/Cargo.toml
+++ b/xpallets/mining/asset/rpc/Cargo.toml
@@ -18,6 +18,9 @@ sp-api = "2.0.0"
 sp-blockchain = "2.0.0"
 sp-runtime = "2.0.0"
 
+# ChainX primitives
+xp-rpc = { path = "../../../../primitives/rpc" }
+
 # ChainX pallets
 xpallet-support = { path = "../../../support" }
 

--- a/xpallets/mining/asset/rpc/src/lib.rs
+++ b/xpallets/mining/asset/rpc/src/lib.rs
@@ -8,14 +8,13 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use codec::Codec;
-use jsonrpc_core::Result;
 use jsonrpc_derive::rpc;
 
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::{generic::BlockId, traits::Block as BlockT};
 
-use xp_rpc::runtime_error_into_rpc_err;
+use xp_rpc::{runtime_error_into_rpc_err, Result};
 
 use xpallet_support::{RpcBalance, RpcMiningWeight};
 

--- a/xpallets/mining/asset/rpc/src/lib.rs
+++ b/xpallets/mining/asset/rpc/src/lib.rs
@@ -3,17 +3,19 @@
 //! RPC interface for the transaction payment module.
 
 use std::collections::btree_map::BTreeMap;
-use std::fmt::{Debug, Display};
+use std::fmt::Display;
 use std::str::FromStr;
 use std::sync::Arc;
 
 use codec::Codec;
-use jsonrpc_core::{Error as RpcError, ErrorCode, Result};
+use jsonrpc_core::Result;
 use jsonrpc_derive::rpc;
 
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::{generic::BlockId, traits::Block as BlockT};
+
+use xp_rpc::runtime_error_into_rpc_err;
 
 use xpallet_support::{RpcBalance, RpcMiningWeight};
 
@@ -172,32 +174,5 @@ where
                     .collect()
             })
             .map_err(runtime_error_into_rpc_err)?)
-    }
-}
-
-/// Error type of this RPC api.
-pub enum Error {
-    /// The transaction was not decodable.
-    DecodeError,
-    /// The call to runtime failed.
-    RuntimeError,
-}
-
-impl From<Error> for i64 {
-    fn from(e: Error) -> i64 {
-        match e {
-            Error::RuntimeError => 1,
-            Error::DecodeError => 2,
-        }
-    }
-}
-
-const RUNTIME_ERROR: i64 = 1;
-/// Converts a runtime trap into an RPC error.
-fn runtime_error_into_rpc_err(err: impl Debug) -> RpcError {
-    RpcError {
-        code: ErrorCode::ServerError(RUNTIME_ERROR),
-        message: "Runtime trapped".into(),
-        data: Some(format!("{:?}", err).into()),
     }
 }

--- a/xpallets/mining/staking/rpc/Cargo.toml
+++ b/xpallets/mining/staking/rpc/Cargo.toml
@@ -18,6 +18,9 @@ sp-api = "2.0.0"
 sp-blockchain = "2.0.0"
 sp-runtime = "2.0.0"
 
+# ChainX primitives
+xp-rpc = { path = "../../../../primitives/rpc" }
+
 # ChainX pallets
 xpallet-support = { path = "../../../support" }
 

--- a/xpallets/mining/staking/rpc/src/lib.rs
+++ b/xpallets/mining/staking/rpc/src/lib.rs
@@ -8,14 +8,13 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use codec::Codec;
-use jsonrpc_core::Result;
 use jsonrpc_derive::rpc;
 
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::{generic::BlockId, traits::Block as BlockT};
 
-use xp_rpc::runtime_error_into_rpc_err;
+use xp_rpc::{runtime_error_into_rpc_err, Result};
 
 use xpallet_support::{RpcBalance, RpcVoteWeight};
 

--- a/xpallets/mining/staking/rpc/src/lib.rs
+++ b/xpallets/mining/staking/rpc/src/lib.rs
@@ -3,17 +3,19 @@
 //! RPC interface for the transaction payment module.
 
 use std::collections::btree_map::BTreeMap;
-use std::fmt::{Debug, Display};
+use std::fmt::Display;
 use std::str::FromStr;
 use std::sync::Arc;
 
 use codec::Codec;
-use jsonrpc_core::{Error as RpcError, ErrorCode, Result};
+use jsonrpc_core::Result;
 use jsonrpc_derive::rpc;
 
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::{generic::BlockId, traits::Block as BlockT};
+
+use xp_rpc::runtime_error_into_rpc_err;
 
 use xpallet_support::{RpcBalance, RpcVoteWeight};
 
@@ -232,32 +234,5 @@ where
         Ok(api
             .nominator_info_of(&at, who)
             .map_err(runtime_error_into_rpc_err)?)
-    }
-}
-
-/// Error type of this RPC api.
-pub enum Error {
-    /// The transaction was not decodable.
-    DecodeError,
-    /// The call to runtime failed.
-    RuntimeError,
-}
-
-impl From<Error> for i64 {
-    fn from(e: Error) -> i64 {
-        match e {
-            Error::RuntimeError => 1,
-            Error::DecodeError => 2,
-        }
-    }
-}
-
-const RUNTIME_ERROR: i64 = 1;
-/// Converts a runtime trap into an RPC error.
-fn runtime_error_into_rpc_err(err: impl Debug) -> RpcError {
-    RpcError {
-        code: ErrorCode::ServerError(RUNTIME_ERROR),
-        message: "Runtime trapped".into(),
-        data: Some(format!("{:?}", err).into()),
     }
 }


### PR DESCRIPTION
Before each rpc module defined its error type based the `jsonrpc_core::Error`, the error code is a copy-and-paste everywhere. This PR introduces a rpc primitives to unify the error code in ChainX. The future direction for `xp-rpc` can also be the place for some common rpc infrastructures like `Page`.

Changed:

- `xgatewaycommon_verifyWithdrawal` returns `()` before, now returns `bool`.
- chainx_rpc.json updated https://github.com/chainx-org/ChainX/pull/315/commits/676c8e11f23f8c210ff69fb35581acb3b12fc850. cc @qinghuan-chain 