### PR TITLE
Workaround for fixing the default opts in the unexpected context

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -18,6 +18,23 @@ fn read_config_file(path: &Path) -> Result<HashMap<String, Value>, Box<dyn std::
     }))
 }
 
+const SUB_COMMANDS: [&str; 14] = [
+    "benchmark",
+    "build-spec",
+    "build-sync-spec",
+    "check-block",
+    "export-blocks",
+    "export-state",
+    "help",
+    "import-blocks",
+    "key",
+    "purge-chain",
+    "revert",
+    "sign",
+    "vanity",
+    "verify",
+];
+
 /// Extends the origin cli arg list with the options from the config file.
 ///
 /// Only the options that do not appear in the command line will be appended.
@@ -76,8 +93,14 @@ fn extend_cli_args(
         }
     }
 
-    for (key, value) in default_opts {
-        config_opts.push(format!("--{}={}", key, value));
+    if let Some(sub_command) = cli_args.get(1) {
+        // We are going to invoke the `Run` command.
+        if !SUB_COMMANDS.contains(&sub_command.as_str()) {
+            // `default_opts()` only makes sense in this context.
+            for (key, value) in default_opts {
+                config_opts.push(format!("--{}={}", key, value));
+            }
+        }
     }
 
     let mut args = cli_args;

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -94,9 +94,8 @@ fn extend_cli_args(
     }
 
     if let Some(sub_command) = cli_args.get(1) {
-        // We are going to invoke the `Run` command.
+        // Injecting `default_opts()` only makes sense in the context of no specified subcommands.
         if !SUB_COMMANDS.contains(&sub_command.as_str()) {
-            // `default_opts()` only makes sense in this context.
             for (key, value) in default_opts {
                 config_opts.push(format!("--{}={}", key, value));
             }


### PR DESCRIPTION
Workaround for an issue introduced in #318.

```bash
$ ./target/release/chainx key insert
error: Found argument '--rpc-port' which wasn't expected, or isn't valid in this context

USAGE:
    chainx key insert [FLAGS] [OPTIONS] --key-type <key-type>

For more information try --help
```

The future solution could be implementing the `DefaultConfigurationValues` in ChainX, https://github.com/paritytech/substrate/blob/78fa1b8062218f1ee5a61c499f433a26ca1783aa/client/cli/src/config.rs#L52. But we'll use this hack for now.