### PR TITLE
Fix error when *port in cli-args

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -51,10 +51,14 @@ fn extend_cli_args(
         .collect::<Vec<_>>();
 
     let mut config_opts = Vec::new();
-    let mut default_opts = default_opts;
+    let mut default_opts = default_opts
+        .into_iter()
+        .filter(|(k, _)| !cli_opts.contains(&format!("--{}", k).as_ref()))
+        .collect::<HashMap<_, _>>();
 
     if let Some(path) = path {
         for (key, value) in read_config_file(path)?.into_iter() {
+            // remove key has been configured in config file or in cli arguments.
             if default_opts.contains_key(key.as_str()) {
                 default_opts.remove(key.as_str());
             }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -58,7 +58,7 @@ fn extend_cli_args(
 
     if let Some(path) = path {
         for (key, value) in read_config_file(path)?.into_iter() {
-            // remove key has been configured in config file or in cli arguments.
+            // Remove the option that has been configured in the config file.
             if default_opts.contains_key(key.as_str()) {
                 default_opts.remove(key.as_str());
             }


### PR DESCRIPTION
Fix issue when user put 'rpc-port', 'ws-port', 'port' in cli arguments. It caused by the variable in `cli/src/config.rs:extend_cli_args` doesn't filter out those argument.   