### PR TITLE
Bump up version to 2.0-beta.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,14 +688,14 @@ dependencies = [
 
 [[package]]
 name = "chainx"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "chainx-cli",
 ]
 
 [[package]]
 name = "chainx-cli"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "chainx-executor",
  "chainx-primitives",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "chainx-executor"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "chainx-runtime",
  "frame-benchmarking",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "chainx-primitives"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "frame-system",
  "parity-scale-codec",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "chainx-rpc"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "chainx-primitives",
  "chainx-runtime",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "chainx-runtime"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "chainx-primitives",
  "frame-benchmarking",
@@ -8784,7 +8784,7 @@ dependencies = [
 
 [[package]]
 name = "xp-assets-registrar"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "chainx-primitives",
  "impl-trait-for-tuples",
@@ -8793,7 +8793,7 @@ dependencies = [
 
 [[package]]
 name = "xp-genesis-builder"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "chainx-primitives",
  "serde",
@@ -8802,7 +8802,7 @@ dependencies = [
 
 [[package]]
 name = "xp-io"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "hex",
  "parity-scale-codec",
@@ -8813,11 +8813,11 @@ dependencies = [
 
 [[package]]
 name = "xp-logging"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 
 [[package]]
 name = "xp-mining-common"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "chainx-primitives",
  "sp-arithmetic",
@@ -8827,7 +8827,7 @@ dependencies = [
 
 [[package]]
 name = "xp-mining-staking"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "chainx-primitives",
  "sp-runtime",
@@ -8837,7 +8837,7 @@ dependencies = [
 
 [[package]]
 name = "xp-protocol"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "chainx-primitives",
  "parity-scale-codec",
@@ -8847,7 +8847,7 @@ dependencies = [
 
 [[package]]
 name = "xp-rpc"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "hex",
  "jsonrpc-core",
@@ -8857,7 +8857,7 @@ dependencies = [
 
 [[package]]
 name = "xp-runtime"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "hex",
  "parity-scale-codec",
@@ -8869,7 +8869,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-assets"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "bitflags",
  "chainx-primitives",
@@ -8893,7 +8893,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-assets-registrar"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "chainx-primitives",
  "frame-benchmarking",
@@ -8915,7 +8915,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-assets-rpc"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -8930,7 +8930,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-assets-rpc-runtime-api"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "chainx-primitives",
  "parity-scale-codec",
@@ -8941,7 +8941,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-dex-spot"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "chainx-primitives",
  "env_logger",
@@ -8965,7 +8965,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-dex-spot-rpc"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -8981,7 +8981,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-dex-spot-rpc-runtime-api"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8991,7 +8991,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-gateway-bitcoin"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "bs58",
  "chainx-primitives",
@@ -9023,7 +9023,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-gateway-common"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "bs58",
  "chainx-primitives",
@@ -9054,7 +9054,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-gateway-common-rpc"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "hex",
  "jsonrpc-core",
@@ -9070,7 +9070,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-gateway-common-rpc-runtime-api"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "chainx-primitives",
  "parity-scale-codec",
@@ -9084,7 +9084,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-gateway-records"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "chainx-primitives",
  "frame-benchmarking",
@@ -9108,7 +9108,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-gateway-records-rpc"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -9125,7 +9125,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-gateway-records-rpc-runtime-api"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "chainx-primitives",
  "parity-scale-codec",
@@ -9137,7 +9137,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-genesis-builder"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "chainx-primitives",
  "frame-support",
@@ -9159,7 +9159,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-mining-asset"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "chainx-primitives",
  "env_logger",
@@ -9188,7 +9188,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-mining-asset-rpc"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -9203,7 +9203,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-mining-asset-rpc-runtime-api"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "chainx-primitives",
  "parity-scale-codec",
@@ -9214,7 +9214,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-mining-staking"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "chainx-primitives",
  "env_logger",
@@ -9244,7 +9244,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-mining-staking-rpc"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -9259,7 +9259,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-mining-staking-rpc-runtime-api"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9269,7 +9269,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-support"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "hex",
  "sp-std",
@@ -9277,7 +9277,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-system"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9290,7 +9290,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-transaction-fee"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9303,7 +9303,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-transaction-fee-rpc"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -9321,7 +9321,7 @@ dependencies = [
 
 [[package]]
 name = "xpallet-transaction-fee-rpc-runtime-api"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 dependencies = [
  "parity-scale-codec",
  "sp-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainx"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 description = "Fully Decentralized Interchain Crypto Asset Management on Polkadot"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainx-cli"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 description = "Implementation of protocol https://chainx.org in Rust based on the Substrate framework."
 edition = "2018"

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainx-executor"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainx-primitives"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/primitives/assets-registrar/Cargo.toml
+++ b/primitives/assets-registrar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xp-assets-registrar"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/primitives/genesis-builder/Cargo.toml
+++ b/primitives/genesis-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xp-genesis-builder"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/primitives/io/Cargo.toml
+++ b/primitives/io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xp-io"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/primitives/logging/Cargo.toml
+++ b/primitives/logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xp-logging"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/primitives/mining/common/Cargo.toml
+++ b/primitives/mining/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xp-mining-common"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/primitives/mining/staking/Cargo.toml
+++ b/primitives/mining/staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xp-mining-staking"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/primitives/protocol/Cargo.toml
+++ b/primitives/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xp-protocol"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/primitives/rpc/Cargo.toml
+++ b/primitives/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xp-rpc"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/primitives/runtime/Cargo.toml
+++ b/primitives/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xp-runtime"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainx-rpc"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainx-runtime"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/assets-registrar/Cargo.toml
+++ b/xpallets/assets-registrar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-assets-registrar"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/assets/Cargo.toml
+++ b/xpallets/assets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-assets"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/assets/rpc/Cargo.toml
+++ b/xpallets/assets/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-assets-rpc"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/assets/rpc/runtime-api/Cargo.toml
+++ b/xpallets/assets/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-assets-rpc-runtime-api"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/dex/spot/Cargo.toml
+++ b/xpallets/dex/spot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-dex-spot"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/dex/spot/rpc/Cargo.toml
+++ b/xpallets/dex/spot/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-dex-spot-rpc"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/dex/spot/rpc/runtime-api/Cargo.toml
+++ b/xpallets/dex/spot/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-dex-spot-rpc-runtime-api"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/gateway/bitcoin/Cargo.toml
+++ b/xpallets/gateway/bitcoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-gateway-bitcoin"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/gateway/common/Cargo.toml
+++ b/xpallets/gateway/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-gateway-common"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/gateway/common/rpc/Cargo.toml
+++ b/xpallets/gateway/common/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-gateway-common-rpc"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/gateway/common/rpc/runtime-api/Cargo.toml
+++ b/xpallets/gateway/common/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-gateway-common-rpc-runtime-api"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/gateway/records/Cargo.toml
+++ b/xpallets/gateway/records/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-gateway-records"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/gateway/records/rpc/Cargo.toml
+++ b/xpallets/gateway/records/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-gateway-records-rpc"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/gateway/records/rpc/runtime-api/Cargo.toml
+++ b/xpallets/gateway/records/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-gateway-records-rpc-runtime-api"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/genesis-builder/Cargo.toml
+++ b/xpallets/genesis-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-genesis-builder"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/mining/asset/Cargo.toml
+++ b/xpallets/mining/asset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-mining-asset"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/mining/asset/rpc/Cargo.toml
+++ b/xpallets/mining/asset/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-mining-asset-rpc"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/mining/asset/rpc/runtime-api/Cargo.toml
+++ b/xpallets/mining/asset/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-mining-asset-rpc-runtime-api"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/mining/staking/Cargo.toml
+++ b/xpallets/mining/staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-mining-staking"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/mining/staking/rpc/Cargo.toml
+++ b/xpallets/mining/staking/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-mining-staking-rpc"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/mining/staking/rpc/runtime-api/Cargo.toml
+++ b/xpallets/mining/staking/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-mining-staking-rpc-runtime-api"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/support/Cargo.toml
+++ b/xpallets/support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-support"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/system/Cargo.toml
+++ b/xpallets/system/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-system"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/transaction-fee/Cargo.toml
+++ b/xpallets/transaction-fee/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-transaction-fee"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/transaction-fee/rpc/Cargo.toml
+++ b/xpallets/transaction-fee/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-transaction-fee-rpc"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 

--- a/xpallets/transaction-fee/rpc/runtime-api/Cargo.toml
+++ b/xpallets/transaction-fee/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xpallet-transaction-fee-rpc-runtime-api"
-version = "2.0.0-beta.0"
+version = "2.0.0-beta.1"
 authors = ["The ChainX Authors"]
 edition = "2018"
 


### PR DESCRIPTION
2.0.0-beta.0 => 2.0.0-beta.1:

- Fix `Burn` config in treasury, there is no burn in ChainX. #332
- Fix cli error when `*-port` is used. #329 
- Report to polkadot telemetry. #333 
- Fix `TotalIssuance` in balances module and make the various period settings in democracy much faster for the testnet. #334