### PR TITLE
Add script to generate various genesis keys

### DIFF
--- a/cli/src/chain_spec.rs
+++ b/cli/src/chain_spec.rs
@@ -33,7 +33,7 @@ use chainx_runtime::{
     XSpotConfig, XStakingConfig, XSystemConfig,
 };
 
-use crate::genesis::assets::{init_assets, pcx, testnet_assets, AssetParams};
+use crate::genesis::assets::{genesis_assets, init_assets, pcx, AssetParams};
 use crate::genesis::bitcoin::{BtcGenesisParams, BtcTrusteeParams};
 
 // Note this is the URL for the telemetry server
@@ -148,7 +148,7 @@ pub fn development_config() -> Result<ChainSpec, String> {
             vec![authority_keys_from_seed("Alice")],
             get_account_id_from_seed::<sr25519::Public>("Alice"),
             get_account_id_from_seed::<sr25519::Public>("vesting"),
-            testnet_assets(),
+            genesis_assets(),
             endowed_gen![
                 ("Alice", endowed_balance),
                 ("Bob", endowed_balance),
@@ -185,7 +185,7 @@ pub fn benchmarks_config() -> Result<ChainSpec, String> {
             vec![authority_keys_from_seed("Alice")],
             get_account_id_from_seed::<sr25519::Public>("Alice"),
             get_account_id_from_seed::<sr25519::Public>("vesting"),
-            testnet_assets(),
+            genesis_assets(),
             endowed_gen![
                 ("Alice", endowed_balance),
                 ("Bob", endowed_balance),
@@ -225,7 +225,7 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
             ],
             get_account_id_from_seed::<sr25519::Public>("Alice"),
             get_account_id_from_seed::<sr25519::Public>("vesting"),
-            testnet_assets(),
+            genesis_assets(),
             endowed_gen![
                 ("Alice", endowed_balance),
                 ("Bob", endowed_balance),
@@ -364,7 +364,7 @@ pub fn staging_testnet_config() -> Result<ChainSpec, String> {
         ),
     ];
 
-    let assets = testnet_assets();
+    let assets = genesis_assets();
     let endowed_balance = 50 * DOLLARS;
     let mut endowed = BTreeMap::new();
     let pcx_id = pcx().0;
@@ -509,7 +509,7 @@ pub fn testnet_config() -> Result<ChainSpec, String> {
         ),
     ];
 
-    let assets = testnet_assets();
+    let assets = genesis_assets();
     let endowed_balance = 50 * DOLLARS;
     let mut endowed = BTreeMap::new();
     let pcx_id = pcx().0;
@@ -559,10 +559,9 @@ pub fn testnet_config() -> Result<ChainSpec, String> {
 pub fn mainnet_config() -> Result<ChainSpec, String> {
     let wasm_binary = WASM_BINARY.ok_or("Development wasm binary not available".to_string())?;
 
-    // subkey inspect-key --uri "$SECRET"
-    // 5HNeqQYeyqcaBTHHjSbFnEvhCeg6jKcRrV2zeHgXQhvjK8XY
+    // 5E9upTw5KfKuVa9nA5E9sfiC3S6pToZmm5NKkdWnfaArA1zD
     let root_key: AccountId =
-        hex!["eadd6992f5b27027c9424be83d460fcd71550aa8ba3c322ff25548565ca6395d"].into();
+        hex!["5c70f62d9ac4bc0a314100d5d3b74d127dbcf8628329ffa799361ae69e104768"].into();
 
     // export SECRET="YOUR SECRET"
     // cd scripts/genesis/generate_keys.sh && bash generate_keys.sh
@@ -675,7 +674,7 @@ pub fn mainnet_config() -> Result<ChainSpec, String> {
         ),
     ];
 
-    let assets = testnet_assets();
+    let assets = genesis_assets();
     // 1000PCX
     // TODO: deduct 5000 PCX from legacy team account.
     let endowed_balance = 100_000 * DOLLARS;

--- a/cli/src/chain_spec.rs
+++ b/cli/src/chain_spec.rs
@@ -680,6 +680,7 @@ pub fn mainnet_config() -> Result<ChainSpec, String> {
             genesis_assets(),
             // FIXME update btc mainnet header
             btc_genesis_params(include_str!("res/btc_genesis_params_mainnet.json")),
+            // FIXME mainnet_trustees()
             staging_testnet_trustees(),
         )
     };

--- a/cli/src/chain_spec.rs
+++ b/cli/src/chain_spec.rs
@@ -549,6 +549,7 @@ pub fn testnet_config() -> Result<ChainSpec, String> {
     ))
 }
 
+#[allow(unused)]
 pub fn mainnet_config() -> Result<ChainSpec, String> {
     let wasm_binary = WASM_BINARY.ok_or("Development wasm binary not available".to_string())?;
 

--- a/cli/src/chain_spec.rs
+++ b/cli/src/chain_spec.rs
@@ -559,8 +559,12 @@ pub fn testnet_config() -> Result<ChainSpec, String> {
 pub fn mainnet_config() -> Result<ChainSpec, String> {
     let wasm_binary = WASM_BINARY.ok_or("Development wasm binary not available".to_string())?;
 
-    // 5E9upTw5KfKuVa9nA5E9sfiC3S6pToZmm5NKkdWnfaArA1zD
+    // 5HNeqQYeyqcaBTHHjSbFnEvhCeg6jKcRrV2zeHgXQhvjK8XY
     let root_key: AccountId =
+        hex!["eadd6992f5b27027c9424be83d460fcd71550aa8ba3c322ff25548565ca6395d"].into();
+
+    // 5E9upTw5KfKuVa9nA5E9sfiC3S6pToZmm5NKkdWnfaArA1zD
+    let vesting_key: AccountId =
         hex!["5c70f62d9ac4bc0a314100d5d3b74d127dbcf8628329ffa799361ae69e104768"].into();
 
     // export SECRET="YOUR SECRET"
@@ -691,7 +695,7 @@ pub fn mainnet_config() -> Result<ChainSpec, String> {
             &wasm_binary[..],
             initial_authorities.clone(),
             root_key.clone(),
-            root_key.clone(), // use root key as vesting_account
+            vesting_key.clone(),
             assets.clone(),
             endowed.clone(),
             // FIXME update btc mainnet header

--- a/cli/src/chain_spec.rs
+++ b/cli/src/chain_spec.rs
@@ -751,12 +751,16 @@ fn build_genesis(
 
     let num_endowed_accounts = endowed_accounts.len();
 
+    let mut total_endowed = Balance::default();
     let balances = endowed
         .get(&PCX)
         .expect("PCX endowed; qed")
         .iter()
         .cloned()
-        .map(|(k, _)| (k, ENDOWMENT))
+        .map(|(k, _)| {
+            total_endowed += ENDOWMENT;
+            (k, ENDOWMENT)
+        })
         .collect::<Vec<_>>();
 
     // The value of STASH balance will be reserved per phragmen member.
@@ -881,6 +885,7 @@ fn build_genesis(
         }),
         xpallet_genesis_builder: Some(XGenesisBuilderConfig {
             params: crate::genesis::genesis_builder_params(),
+            total_endowed,
         }),
     }
 }
@@ -908,14 +913,14 @@ fn mainnet_genesis(
         .cloned()
         .collect::<Vec<_>>();
 
-    // 1000PCX
-    // TODO: deduct 5000 PCX from legacy team account.
     let balances = initial_authorities
         .iter()
         .map(|((validator, _), _, _, _, _, _)| validator)
         .cloned()
         .map(|validator| (validator, STAKING_LOCKED))
         .collect::<Vec<_>>();
+
+    let total_endowed = initial_authorities_len as Balance * STAKING_LOCKED;
 
     let validators = initial_authorities
         .clone()
@@ -1021,6 +1026,7 @@ fn mainnet_genesis(
         }),
         xpallet_genesis_builder: Some(XGenesisBuilderConfig {
             params: crate::genesis::genesis_builder_params(),
+            total_endowed,
         }),
     }
 }

--- a/cli/src/chain_spec.rs
+++ b/cli/src/chain_spec.rs
@@ -555,6 +555,171 @@ pub fn testnet_config() -> Result<ChainSpec, String> {
     ))
 }
 
+pub fn mainnet_config() -> Result<ChainSpec, String> {
+    let wasm_binary = WASM_BINARY.ok_or("Development wasm binary not available".to_string())?;
+
+    // subkey inspect-key --uri "$SECRET"
+    // 5HNeqQYeyqcaBTHHjSbFnEvhCeg6jKcRrV2zeHgXQhvjK8XY
+    let root_key: AccountId =
+        hex!["eadd6992f5b27027c9424be83d460fcd71550aa8ba3c322ff25548565ca6395d"].into();
+
+    // export SECRET="YOUR SECRET"
+    // cd scripts/genesis/generate_keys.sh && bash generate_keys.sh
+
+    let initial_authorities: Vec<AuthorityKeysTuple> = vec![
+        (
+            (
+                // 5DPgEmPRBhXj8fpsHm3aXrNtjXNVv7MHnUYQVLFhzMyzabaN
+                hex!["3ab47230dff92003f6f4f79cf7930cfe3f3fd77eedfea55acfde77223ac1a47a"].into(),
+                b"Validator1".to_vec(),
+            ),
+            // 5GgaYZcQyHMk75VxvYQVQR3b2gxsPawsgGXjx8vhCiiTabLR
+            hex!["cc4d27469504538539515615deb495c2901a774abd1a13655336b615d4014a3c"].into(),
+            // 5EPgwcbLknydnWGmHem3rmwhdjk55e9HfoqjF5A5zRQDkWxj
+            hex!["66f30ce2de3f23c2383c0ecea1e2a2e0520c18931d3a9bca64be78e3f9f7b62f"]
+                .unchecked_into(),
+            // 5FTYv429Xnkmn7HR4FCWPxnTpvveqpqjVKng3H6ypaBpXeVN
+            hex!["96213e8f2f57edfec52b6ffc260d4e8257e8addabe7797fa197f0aa8f6b7e748"]
+                .unchecked_into(),
+            // 5G4KNiQahHTY1LSafhfZnwGLtAnB39TMuc9nhpWMerE98RYQ
+            hex!["b0a540b56805d5b14df2787360728d72197bec577601ad49e274d3914f8b407a"]
+                .unchecked_into(),
+            // 5HNR82T2juJY6hx48ExdwUBQcpHQvHc5QPCcEzusdHMtLfMZ
+            hex!["eaaf3faeb72a15004fb5f9c68de188310b8cf3fbbbd8e8eb4db8aa9e95c40966"]
+                .unchecked_into(),
+        ),
+        (
+            (
+                // 5HmRZ2viuTVEcxD1DgF89DvnHptVsqYyN27DvPwiSMUoiFhB
+                hex!["fc3b583310fe9f091e35a8be64ac9508b9d3c088fdcef51b747113fa8fe87f44"].into(),
+                b"Validator2".to_vec(),
+            ),
+            // 5E4ayu9boQK88fkBRCb5D2KeFHzqko3xeBsjidgnVBZrEKvM
+            hex!["5861528f602af4e6237e8c0724885db5aa2a8c2faa44ba539d2436021537be04"].into(),
+            // 5FLeZHeNy7UPyNusqLRT4EUqxBxUVEpSbma6u9By6DzC3o13
+            hex!["90dd84e695fd85888d9060ded9a79a7b6bca69206cf10d5366f10c12822c9424"]
+                .unchecked_into(),
+            // 5Hi3u6dHDtemnL18s6gr6CduTbXEFJg4Jx4LX5YWVc4HAwnC
+            hex!["f9a8b6d66d3efbd77b304feea7c142b801cd04422e250d548f063750c890ff1a"]
+                .unchecked_into(),
+            // 5FbwQEszvNLmcJzbVaSGUccLpri3waR49xFD6Zt3fNd48wqF
+            hex!["9c86e6f5ac9ef21d27500d3bfdc9900c17911a4dba1a29ccd32268c208d6c24f"]
+                .unchecked_into(),
+            // 5ENpkyLe4xNRz1siYybtQnhEfvgJc6zsb2Go5dZLHTSdGZNt
+            hex!["664a1e1eccab98fb1f7c1b20c16b1f010ed5a1ec13648b6c57f336ebb44d865a"]
+                .unchecked_into(),
+        ),
+        (
+            (
+                // 5FEMghsWkqKi8wR7r95jPg6DnGErv9w7AfZF7nMkjUqHy421
+                hex!["8c114008f432dd0f10dc74a78d1f6cdef6778bb30c3d5abfcf60f5f1570a6b43"].into(),
+                b"Validator3".to_vec(),
+            ),
+            // 5FeZHG9fpPKxzjMikjX39FXvUdG4JJ2yhHpA2YBGywtWzCcK
+            hex!["9e862cbf1bb26bed7660f725317f53a5c40dd50aa4e36d81263681651a6f2931"].into(),
+            // 5Grs98EMvxsCrmKMKGCx3xemYcMhAPNF8aa6uRYttWVKJLBg
+            hex!["d4257968d6f6775c356c9bac1fcce8d420cd1e03e704dc5c4c5c33b0182c471a"]
+                .unchecked_into(),
+            // 5EaDXXayhSHc49gXk7i7frh8tFwmtWAL2Sb9zjtaGhBCbNib
+            hex!["6efa76335d099850aa2ef10a15f20e9d305f7eec9b0079f8196c7aa9deff07ed"]
+                .unchecked_into(),
+            // 5GBQRvZ4FXZi1ttKCMHQN99X4qtegoQ3aRAyqjxyKuRZ8qnX
+            hex!["b60cfd05f854c298b4fdaac6d1b2d58e94f870ce0ce3f98d1863e56479d19776"]
+                .unchecked_into(),
+            // 5CB4Smxj5szwZGr1n1ebzEW4HHu8aPqndiZ2oAZGXdDnLFsK
+            hex!["04d8c72b0f7cfe7ce77da151a4b3f6d68295f4740cd4f0ce00d1d197d4758e42"]
+                .unchecked_into(),
+        ),
+        (
+            (
+                // 5EhdQUJkAcaBMmDpAmc2vMhLoRTjUxHgbXmsun7CSawXu6To
+                hex!["74a18faa6693cf68b988c479799b9e5fff4c131beb055acdab30c11570df0978"].into(),
+                b"Validator4".to_vec(),
+            ),
+            // 5ERRsAvNXWhZmqG4tdjcGEgJHCkqYSDSdsdqAq3GGoRGpu9m
+            hex!["6846c9ee8d47c20bda6d4458bef2677e75a2dc2df93a506e36c03cb6d53e801f"].into(),
+            // 5CJPSYjvaCi2M7izUXwg5pqkQqhaJiHgDX9gz1JoKQrY18jo
+            hex!["0a6f713ac4f6773b688be912174a67b6e708386dc2466391c5ba23037ce69951"]
+                .unchecked_into(),
+            // 5EoaYFrxhUBpvUh1u4EqBRbXkAEZ7mnn45tqz93fvGz3mFxd
+            hex!["792b62f72b315be07d5ba5b1492ec2010b69612e03ea89635448eefa0aaff722"]
+                .unchecked_into(),
+            // 5Cr1Jnhp8p3BQfez9GxZkMaMemPb6PpaqbqkwWWdcwj7W3Qc
+            hex!["228cc94abf939b2e38dc932fb87e970fdcdb04b906e29ccf2669ef7cda56836a"]
+                .unchecked_into(),
+            // 5DNpp5jtdht5JBBUoUtFc46YrgBLeJwP5QyLtQ6fGyii4nkV
+            hex!["3a0e10920f8f5f1880d25a1b9d04ce936d64c4a84060428133347cc1c83e8a64"]
+                .unchecked_into(),
+        ),
+        (
+            (
+                // 5EvXt55kDmAXbBPqrzvNZcbE6bvZ8eWBThxJptoDkwAAyEkw
+                hex!["7e7927d030d89585cd66f0d44313de41f4c697da387159786f8b3ed5cd081d4f"].into(),
+                b"Validator5".to_vec(),
+            ),
+            // 5FyRpivr8qN9sK1PU9Qhutv4QwVnHomFGgMn93khwCbDCBXq
+            hex!["aceabbac700af582fe4ff6084ba1c778339fbadccb1c182d82817aacdfcb5345"].into(),
+            // 5D83WrH4h4rPFxe4m4xGMuC8XuR9jqWHggHBriZQELJ3JneN
+            hex!["2ec8253a23695069619df42213106402cffb217bb02c653c11e3435eb047e60d"]
+                .unchecked_into(),
+            // 5GpHoku58fumTfn9pQZxKFxASvMw6JNTqmFDQw92g7LV1gwj
+            hex!["d22ec57d5cdb6f80f0df82590f9999b88e936e9f8c93d9c05cd87dba1b4567ae"]
+                .unchecked_into(),
+            // 5HCBmPYr7AsXDp4VLu7qh6HRExjy2Nx33YLHqLeQ6i7yFjHt
+            hex!["e2e1d5c8eb42aa6b37f71cbdc8e73b67b385e7841d98bbaef3492252a4f3e605"]
+                .unchecked_into(),
+            // 5HQYBwyf2787MCMhZNBEpswHJcJnXVVNxjrdTa6cVjUf29jy
+            hex!["ec4d8806b85969a29214c00ae70b5d239dc65daebf2ea4a43fd47a77e16d9c7c"]
+                .unchecked_into(),
+        ),
+    ];
+
+    let assets = testnet_assets();
+    // 1000PCX
+    // TODO: deduct 5000 PCX from legacy team account.
+    let endowed_balance = 100_000 * DOLLARS;
+    let mut endowed = BTreeMap::new();
+    let pcx_id = pcx().0;
+    let endowed_info = initial_authorities
+        .iter()
+        .map(|i| ((i.0).0.clone(), endowed_balance))
+        .collect::<Vec<_>>();
+    endowed.insert(pcx_id, endowed_info);
+
+    let constructor = move || {
+        build_genesis(
+            &wasm_binary[..],
+            initial_authorities.clone(),
+            root_key.clone(),
+            root_key.clone(), // use root key as vesting_account
+            assets.clone(),
+            endowed.clone(),
+            // FIXME update btc mainnet header
+            crate::genesis::bitcoin::btc_genesis_params(include_str!(
+                "res/btc_genesis_params_mainnet.json"
+            )),
+            crate::genesis::bitcoin::staging_testnet_trustees(),
+        )
+    };
+    Ok(ChainSpec::from_genesis(
+        "ChainX",
+        "chainx",
+        ChainType::Live,
+        constructor,
+        bootnodes![], // FIXME Add mainnet bootnodes
+        Some(
+            TelemetryEndpoints::new(vec![
+                (CHAINX_TELEMETRY_URL.to_string(), 0),
+                (POLKADOT_TELEMETRY_URL.to_string(), 0),
+            ])
+            .expect("ChainX telemetry url is valid; qed"),
+        ),
+        Some("pcx"),
+        Some(as_properties(NetworkType::Mainnet)),
+        Default::default(),
+    ))
+}
+
 fn pcx() -> (AssetId, AssetInfo, AssetRestrictions) {
     (
         PCX,

--- a/cli/src/chain_spec.rs
+++ b/cli/src/chain_spec.rs
@@ -34,7 +34,10 @@ use chainx_runtime::{
 };
 
 use crate::genesis::assets::{genesis_assets, init_assets, pcx, AssetParams};
-use crate::genesis::bitcoin::{BtcGenesisParams, BtcTrusteeParams};
+use crate::genesis::bitcoin::{
+    btc_genesis_params, local_testnet_trustees, staging_testnet_trustees, BtcGenesisParams,
+    BtcTrusteeParams,
+};
 
 // Note this is the URL for the telemetry server
 const POLKADOT_TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
@@ -155,10 +158,8 @@ pub fn development_config() -> Result<ChainSpec, String> {
                 ("Alice//stash", endowed_balance),
                 ("Bob//stash", endowed_balance),
             ],
-            crate::genesis::bitcoin::btc_genesis_params(include_str!(
-                "res/btc_genesis_params_testnet.json"
-            )),
-            crate::genesis::bitcoin::local_testnet_trustees(),
+            btc_genesis_params(include_str!("res/btc_genesis_params_testnet.json")),
+            local_testnet_trustees(),
         )
     };
     Ok(ChainSpec::from_genesis(
@@ -192,9 +193,7 @@ pub fn benchmarks_config() -> Result<ChainSpec, String> {
                 ("Alice//stash", endowed_balance),
                 ("Bob//stash", endowed_balance),
             ],
-            crate::genesis::bitcoin::btc_genesis_params(include_str!(
-                "res/btc_genesis_params_mainnet.json"
-            )),
+            btc_genesis_params(include_str!("res/btc_genesis_params_mainnet.json")),
             crate::genesis::bitcoin::benchmarks_trustees(),
         )
     };
@@ -240,10 +239,8 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
                 ("Eve//stash", endowed_balance),
                 ("Ferdie//stash", endowed_balance),
             ],
-            crate::genesis::bitcoin::btc_genesis_params(include_str!(
-                "res/btc_genesis_params_testnet.json"
-            )),
-            crate::genesis::bitcoin::local_testnet_trustees(),
+            btc_genesis_params(include_str!("res/btc_genesis_params_testnet.json")),
+            local_testnet_trustees(),
         )
     };
     Ok(ChainSpec::from_genesis(
@@ -382,10 +379,8 @@ pub fn staging_testnet_config() -> Result<ChainSpec, String> {
             root_key.clone(), // use root key as vesting_account
             assets.clone(),
             endowed.clone(),
-            crate::genesis::bitcoin::btc_genesis_params(include_str!(
-                "res/btc_genesis_params_testnet.json"
-            )),
-            crate::genesis::bitcoin::staging_testnet_trustees(),
+            btc_genesis_params(include_str!("res/btc_genesis_params_testnet.json")),
+            staging_testnet_trustees(),
         )
     };
     Ok(ChainSpec::from_genesis(
@@ -527,10 +522,8 @@ pub fn testnet_config() -> Result<ChainSpec, String> {
             root_key.clone(), // use root key as vesting_account
             assets.clone(),
             endowed.clone(),
-            crate::genesis::bitcoin::btc_genesis_params(include_str!(
-                "res/btc_genesis_params_testnet.json"
-            )),
-            crate::genesis::bitcoin::staging_testnet_trustees(),
+            btc_genesis_params(include_str!("res/btc_genesis_params_testnet.json")),
+            staging_testnet_trustees(),
         )
     };
     Ok(ChainSpec::from_genesis(
@@ -686,10 +679,8 @@ pub fn mainnet_config() -> Result<ChainSpec, String> {
             vesting_key.clone(),
             genesis_assets(),
             // FIXME update btc mainnet header
-            crate::genesis::bitcoin::btc_genesis_params(include_str!(
-                "res/btc_genesis_params_mainnet.json"
-            )),
-            crate::genesis::bitcoin::staging_testnet_trustees(),
+            btc_genesis_params(include_str!("res/btc_genesis_params_mainnet.json")),
+            staging_testnet_trustees(),
         )
     };
 

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -48,7 +48,9 @@ impl SubstrateCli for Cli {
 
 fn load_spec(id: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {
     Ok(match id {
-        "" | "mainnet" => Box::new(chain_spec::mainnet_config()?),
+        "" | "mainnet" => {
+            return Err("mainnet is not ready, please use --chain=testnet".into());
+        }
         "dev" => Box::new(chain_spec::development_config()?),
         "local" => Box::new(chain_spec::local_testnet_config()?),
         "staging" => Box::new(chain_spec::staging_testnet_config()?),

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -48,7 +48,7 @@ impl SubstrateCli for Cli {
 
 fn load_spec(id: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {
     Ok(match id {
-        "" | "mainnet" => unimplemented!("not impl mainnet config yet."),
+        "" | "mainnet" => Box::new(chain_spec::mainnet_config()?),
         "dev" => Box::new(chain_spec::development_config()?),
         "local" => Box::new(chain_spec::local_testnet_config()?),
         "staging" => Box::new(chain_spec::staging_testnet_config()?),

--- a/cli/src/genesis/assets.rs
+++ b/cli/src/genesis/assets.rs
@@ -1,0 +1,66 @@
+// Copyright 2019-2020 ChainX Project Authors. Licensed under GPL-3.0.
+
+use xp_protocol::{BTC_DECIMALS, PCX, PCX_DECIMALS, X_BTC};
+
+use chainx_runtime::{AssetId, AssetInfo, AssetRestrictions, Chain, Runtime};
+
+pub(crate) type AssetParams = (AssetId, AssetInfo, AssetRestrictions, bool, bool);
+
+pub(crate) fn init_assets(
+    assets: Vec<AssetParams>,
+) -> (
+    Vec<(AssetId, AssetInfo, bool, bool)>,
+    Vec<(AssetId, AssetRestrictions)>,
+) {
+    let mut init_assets = vec![];
+    let mut assets_restrictions = vec![];
+    for (a, b, c, d, e) in assets {
+        init_assets.push((a, b, d, e));
+        assets_restrictions.push((a, c))
+    }
+    (init_assets, assets_restrictions)
+}
+
+pub(crate) fn pcx() -> (AssetId, AssetInfo, AssetRestrictions) {
+    (
+        PCX,
+        AssetInfo::new::<Runtime>(
+            b"PCX".to_vec(),
+            b"Polkadot ChainX".to_vec(),
+            Chain::ChainX,
+            PCX_DECIMALS,
+            b"ChainX's crypto currency in Polkadot ecology".to_vec(),
+        )
+        .unwrap(),
+        AssetRestrictions::DEPOSIT
+            | AssetRestrictions::WITHDRAW
+            | AssetRestrictions::DESTROY_WITHDRAWAL
+            | AssetRestrictions::DESTROY_USABLE,
+    )
+}
+
+pub(crate) fn xbtc() -> (AssetId, AssetInfo, AssetRestrictions) {
+    (
+        X_BTC,
+        AssetInfo::new::<Runtime>(
+            b"XBTC".to_vec(),
+            b"ChainX Bitcoin".to_vec(),
+            Chain::Bitcoin,
+            BTC_DECIMALS,
+            b"ChainX's Cross-chain Bitcoin".to_vec(),
+        )
+        .unwrap(),
+        AssetRestrictions::DESTROY_USABLE,
+    )
+}
+
+// asset_id, asset_info, asset_restrictions, is_online, has_mining_rights
+pub(crate) fn testnet_assets() -> Vec<(AssetId, AssetInfo, AssetRestrictions, bool, bool)> {
+    let pcx = pcx();
+    let btc = xbtc();
+    let assets = vec![
+        (pcx.0, pcx.1, pcx.2, true, false),
+        (btc.0, btc.1, btc.2, true, true),
+    ];
+    assets
+}

--- a/cli/src/genesis/assets.rs
+++ b/cli/src/genesis/assets.rs
@@ -55,7 +55,7 @@ pub(crate) fn xbtc() -> (AssetId, AssetInfo, AssetRestrictions) {
 }
 
 // asset_id, asset_info, asset_restrictions, is_online, has_mining_rights
-pub(crate) fn testnet_assets() -> Vec<(AssetId, AssetInfo, AssetRestrictions, bool, bool)> {
+pub(crate) fn genesis_assets() -> Vec<(AssetId, AssetInfo, AssetRestrictions, bool, bool)> {
     let pcx = pcx();
     let btc = xbtc();
     let assets = vec![

--- a/cli/src/genesis/mod.rs
+++ b/cli/src/genesis/mod.rs
@@ -1,5 +1,6 @@
 // Copyright 2019-2020 ChainX Project Authors. Licensed under GPL-3.0.
 
+pub mod assets;
 pub mod bitcoin;
 
 use xp_genesis_builder::AllParams;

--- a/scripts/genesis/README.md
+++ b/scripts/genesis/README.md
@@ -24,7 +24,7 @@ $ ./btc_genesis_params_gen.py 576576 --network Testnet
 
 ## `generate_keys.sh`
 
-This script can be used for generating the various keys for the multiple genesis validators, e.g., babe, grandpa.
+This script can be used for generating the various keys for the multiple genesis validators, e.g., babe, grandpa. It's useful when you plan to start a brand new chain.
 
 Note: If the output format of command `subkey key inspect-key` changes, this script probably should be updated accordingly, it's only guaranteed to work with the following output of `subkey key inspect-key`:
 

--- a/scripts/genesis/README.md
+++ b/scripts/genesis/README.md
@@ -21,3 +21,26 @@ $ ./btc_genesis_params_gen.py 576576
 # Generate block params from Bitcoin testnet at height 576576.
 $ ./btc_genesis_params_gen.py 576576 --network Testnet
 ```
+
+## `generate_keys.sh`
+
+This script can be used for generating the various keys for the multiple genesis validators, e.g., babe, grandpa.
+
+Note: If the output format of command `subkey key inspect-key` changes, this script probably should be updated accordingly, it's only guaranteed to work with the following output of `subkey key inspect-key`:
+
+```
+Secret phrase `bottom drive obey lake curtain smoke basket hold race lonely fit walk` is account:
+  Secret seed:      0xfac7959dbfe72f052e5a0c3c8d6530f202b02fd8f9f5ca3580ec8deb7797479e
+  Public key (hex): 0x46ebddef8cd9bb167dc30878d7113b7e168e6f0646beffd77d69d39bad76b47a
+  Account ID:       0x46ebddef8cd9bb167dc30878d7113b7e168e6f0646beffd77d69d39bad76b47a
+  SS58 Address:     5DfhGyQdFobKM8NsWvEeAKk5EQQgYe9AydgJ7rMB6E1EqRzV
+```
+
+### Usage
+
+```bash
+$ cargo build --release
+$ cd scripts/genesis
+$ export SECRET="YOUR SECRET"
+$ bash generate_keys.sh
+```

--- a/scripts/genesis/generate_keys.sh
+++ b/scripts/genesis/generate_keys.sh
@@ -55,32 +55,37 @@ generate_aux_key() {
   print_aux_key  "$scheme" "$uri"
 }
 
-for id in 1 2 3 4 5; do
-  echo "SECRET//validator//$id:"
-  echo "SECRET//blockauthor/$id, SECRET//babe//$id, SECRET//grandpa//$id, SECRET//im_online//$id, SECRET//authority_discovery//$id"
-  echo
+main() {
+  # Generate 5 pairs of genesis keys given the root secret
+  for id in 1 2 3 4 5; do
+    echo "SECRET//validator//$id:"
+    echo "SECRET//blockauthor/$id, SECRET//babe//$id, SECRET//grandpa//$id, SECRET//im_online//$id, SECRET//authority_discovery//$id"
+    echo
 
-  echo "            ("
-  print_validator_address "$SECRET//validator//$id"
-  print_validator_id      "$SECRET//validator//$id"
+    echo "            ("
+    print_validator_address "$SECRET//validator//$id"
+    print_validator_id      "$SECRET//validator//$id"
 
-  referral_id="Validator$id"
-  echo "                b\""$referral_id"\".to_vec(),"
-  echo "            ),"
+    referral_id="Validator$id"
+    echo "                b\""$referral_id"\".to_vec(),"
+    echo "            ),"
 
-  print_address      sr25519 "$SECRET//blockauthor//$id"
-  print_account_key          "$SECRET//blockauthor//$id"
+    print_address      sr25519 "$SECRET//blockauthor//$id"
+    print_account_key          "$SECRET//blockauthor//$id"
 
-  generate_aux_key babe sr25519 "$DIR/$id" "$SECRET//babe//$id"
-  # Grandpa must use ed25519.
-  generate_aux_key gran ed25519 "$DIR/$id" "$SECRET//grandpa//$id"
-  generate_aux_key imon sr25519 "$DIR/$id" "$SECRET//im_online//$id"
-  generate_aux_key audi sr25519 "$DIR/$id" "$SECRET//authority_discovery//$id"
+    generate_aux_key babe sr25519 "$DIR/$id" "$SECRET//babe//$id"
+    # Grandpa must use ed25519.
+    generate_aux_key gran ed25519 "$DIR/$id" "$SECRET//grandpa//$id"
+    generate_aux_key imon sr25519 "$DIR/$id" "$SECRET//im_online//$id"
+    generate_aux_key audi sr25519 "$DIR/$id" "$SECRET//authority_discovery//$id"
 
-  echo
-done
+    echo
+  done
 
-echo 'Root:'
-print_address     sr25519 "$SECRET"
-print_account_key         "$SECRET"
-echo "The generated keys are in directory $DIR"
+  echo 'Root:'
+  print_address     sr25519 "$SECRET"
+  print_account_key         "$SECRET"
+  echo "The generated keys are in directory $DIR"
+}
+
+main

--- a/scripts/genesis/generate_keys.sh
+++ b/scripts/genesis/generate_keys.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+# Generate the various keys for the gensis.
+#
+# This script will print the info to stdout in a form which is slightly easier to be
+# copied and pasted to the Rust source file.
+
+set -e
+
+if [[ -z "${SECRET}" ]]; then
+  echo 'ERROR: $SECRET unset, please export the environment varible $SECRET first.'
+  exit 1
+fi
+
+CHAIN=mainnet
+DIR="keys"
+CHAINX=../../target/release/chainx
+
+print_validator_address() {
+  address=$("$CHAINX" key inspect-key "$1" | tail -n 1 | awk '{print $NF}')
+  echo "                // $address"
+}
+
+print_validator_id() {
+  pubkey=$("$CHAINX" key inspect-key "$1" | tail -n 3 | head -1 | awk '{print $NF}')
+  echo "                hex![\"${pubkey:2}\"].into(),"
+}
+
+print_address() {
+  local_scheme=$1
+  local_uri=$2
+  address=$("$CHAINX" key inspect-key --scheme "$local_scheme" "$local_uri" | tail -n 1 | awk '{print $NF}')
+  echo "            // $address"
+}
+
+print_account_key() {
+  pubkey=$("$CHAINX" key inspect-key "$1" | tail -n 3 | head -1 | awk '{print $NF}')
+  echo "            hex![\"${pubkey:2}\"].into(),"
+}
+
+print_aux_key() {
+  local_scheme=$1
+  local_uri=$2
+  pubkey=$("$CHAINX" key inspect-key --scheme "$local_scheme"  "$local_uri" | tail -n 3 | head -1 | awk '{print $NF}')
+  echo "            hex![\"${pubkey:2}\"].unchecked_into(),"
+}
+
+generate_aux_key() {
+  key_type=$1
+  scheme=$2
+  dir=$3
+  uri=$4
+  "$CHAINX" key insert --chain=$CHAIN --key-type "$key_type" -d $dir --scheme "$scheme" --suri "$uri"
+  print_address  "$scheme" "$uri"
+  print_aux_key  "$scheme" "$uri"
+}
+
+for id in 1 2 3 4 5; do
+  echo "SECRET//validator//$id:"
+  echo "SECRET//blockauthor/$id, SECRET//babe//$id, SECRET//grandpa//$id, SECRET//im_online//$id, SECRET//authority_discovery//$id"
+  echo
+
+  echo "            ("
+  print_validator_address "$SECRET//validator//$id"
+  print_validator_id      "$SECRET//validator//$id"
+
+  referral_id="Validator$id"
+  echo "                b\""$referral_id"\".to_vec(),"
+  echo "            ),"
+
+  print_address      sr25519 "$SECRET//blockauthor//$id"
+  print_account_key          "$SECRET//blockauthor//$id"
+
+  generate_aux_key babe sr25519 "$DIR/$id" "$SECRET//babe//$id"
+  # Grandpa must use ed25519.
+  generate_aux_key gran ed25519 "$DIR/$id" "$SECRET//grandpa//$id"
+  generate_aux_key imon sr25519 "$DIR/$id" "$SECRET//im_online//$id"
+  generate_aux_key audi sr25519 "$DIR/$id" "$SECRET//authority_discovery//$id"
+
+  echo
+done
+
+echo 'Root:'
+print_address     sr25519 "$SECRET"
+print_account_key         "$SECRET"
+echo "The generated keys are in directory $DIR"


### PR DESCRIPTION
This PR mainly adds a bash script for generating the keys for initial authorities, useful when we want to prepare a branch new network. An incomplete mainnet config is also added.