### PR TITLE
Deposit Minted event for issuing new balances to the mining assets' pots

### DIFF
--- a/xpallets/mining/asset/src/impls.rs
+++ b/xpallets/mining/asset/src/impls.rs
@@ -304,5 +304,6 @@ impl<T: Trait> xp_mining_staking::AssetMining<BalanceOf<T>> for Module<T> {
     fn reward(asset_id: AssetId, value: BalanceOf<T>) {
         let reward_pot = T::DetermineRewardPotAccount::reward_pot_account_for(&asset_id);
         <T as xpallet_assets::Trait>::Currency::deposit_creating(&reward_pot, value);
+        Self::deposit_event(Event::<T>::Minted(reward_pot, value));
     }
 }

--- a/xpallets/mining/asset/src/lib.rs
+++ b/xpallets/mining/asset/src/lib.rs
@@ -143,6 +143,8 @@ decl_event!(
     {
         /// An asset miner claimed the mining reward. [claimer, asset_id, amount]
         Claimed(AccountId, AssetId, Balance),
+        /// Issue new balance to the reward pot. [reward_pot_account, amount]
+        Minted(AccountId, Balance),
     }
 );
 


### PR DESCRIPTION
So that we can trace the new total issuance by collecting the all `Minted` event.