### PR TITLE
Rename Binding trait and storage

### DIFF
--- a/runtime/chainx/src/lib.rs
+++ b/runtime/chainx/src/lib.rs
@@ -881,7 +881,7 @@ pub struct ReferralGetter;
 impl xpallet_mining_asset::GatewayInterface<AccountId> for ReferralGetter {
     fn referral_of(who: &AccountId, asset_id: AssetId) -> Option<AccountId> {
         use xpallet_gateway_common::traits::ReferralBinding;
-        XGatewayCommon::get_binding_info(&asset_id, who)
+        XGatewayCommon::referral(&asset_id, who)
     }
 }
 

--- a/runtime/chainx/src/lib.rs
+++ b/runtime/chainx/src/lib.rs
@@ -836,8 +836,8 @@ impl xpallet_gateway_bitcoin::Trait for Runtime {
     type AccountExtractor = xp_gateway_bitcoin::OpReturnExtractor;
     type TrusteeSessionProvider = trustees::bitcoin::BtcTrusteeSessionManager<Runtime>;
     type TrusteeOrigin = EnsureSignedBy<trustees::bitcoin::BtcTrusteeMultisig<Runtime>, AccountId>;
-    type Channel = XGatewayCommon;
-    type AddrBinding = XGatewayCommon;
+    type ReferralBinding = XGatewayCommon;
+    type AddressBinding = XGatewayCommon;
     type WeightInfo = xpallet_gateway_bitcoin::weights::SubstrateWeight<Runtime>;
 }
 
@@ -880,7 +880,7 @@ impl xpallet_mining_staking::Trait for Runtime {
 pub struct ReferralGetter;
 impl xpallet_mining_asset::GatewayInterface<AccountId> for ReferralGetter {
     fn referral_of(who: &AccountId, asset_id: AssetId) -> Option<AccountId> {
-        use xpallet_gateway_common::traits::ChannelBinding;
+        use xpallet_gateway_common::traits::ReferralBinding;
         XGatewayCommon::get_binding_info(&asset_id, who)
     }
 }

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -874,7 +874,7 @@ pub struct ReferralGetter;
 impl xpallet_mining_asset::GatewayInterface<AccountId> for ReferralGetter {
     fn referral_of(who: &AccountId, asset_id: AssetId) -> Option<AccountId> {
         use xpallet_gateway_common::traits::ReferralBinding;
-        XGatewayCommon::get_binding_info(&asset_id, who)
+        XGatewayCommon::referral(&asset_id, who)
     }
 }
 

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -830,8 +830,8 @@ impl xpallet_gateway_bitcoin::Trait for Runtime {
     type AccountExtractor = xp_gateway_bitcoin::OpReturnExtractor;
     type TrusteeSessionProvider = trustees::bitcoin::BtcTrusteeSessionManager<Runtime>;
     type TrusteeOrigin = EnsureSignedBy<trustees::bitcoin::BtcTrusteeMultisig<Runtime>, AccountId>;
-    type Channel = XGatewayCommon;
-    type AddrBinding = XGatewayCommon;
+    type ReferralBinding = XGatewayCommon;
+    type AddressBinding = XGatewayCommon;
     type WeightInfo = xpallet_gateway_bitcoin::weights::SubstrateWeight<Runtime>;
 }
 
@@ -873,7 +873,7 @@ impl xpallet_mining_staking::Trait for Runtime {
 pub struct ReferralGetter;
 impl xpallet_mining_asset::GatewayInterface<AccountId> for ReferralGetter {
     fn referral_of(who: &AccountId, asset_id: AssetId) -> Option<AccountId> {
-        use xpallet_gateway_common::traits::ChannelBinding;
+        use xpallet_gateway_common::traits::ReferralBinding;
         XGatewayCommon::get_binding_info(&asset_id, who)
     }
 }

--- a/xpallets/gateway/bitcoin/src/lib.rs
+++ b/xpallets/gateway/bitcoin/src/lib.rs
@@ -48,7 +48,7 @@ use xp_gateway_common::AccountExtractor;
 use xp_logging::{debug, error, info};
 use xpallet_assets::{BalanceOf, Chain, ChainT, WithdrawalLimit};
 use xpallet_gateway_common::{
-    traits::{AddrBinding, ChannelBinding, TrusteeSession},
+    traits::{AddressBinding, ReferralBinding, TrusteeSession},
     trustees::bitcoin::BtcTrusteeAddrInfo,
 };
 use xpallet_support::try_addr;
@@ -81,8 +81,8 @@ pub trait Trait: xpallet_assets::Trait + xpallet_gateway_records::Trait {
     type AccountExtractor: AccountExtractor<Self::AccountId, ReferralId>;
     type TrusteeSessionProvider: TrusteeSession<Self::AccountId, BtcTrusteeAddrInfo>;
     type TrusteeOrigin: EnsureOrigin<Self::Origin, Success = Self::AccountId>;
-    type Channel: ChannelBinding<Self::AccountId>;
-    type AddrBinding: AddrBinding<Self::AccountId, BtcAddress>;
+    type ReferralBinding: ReferralBinding<Self::AccountId>;
+    type AddressBinding: AddressBinding<Self::AccountId, BtcAddress>;
     type WeightInfo: WeightInfo;
 }
 

--- a/xpallets/gateway/bitcoin/src/mock.rs
+++ b/xpallets/gateway/bitcoin/src/mock.rs
@@ -160,8 +160,8 @@ impl Trait for Test {
         xpallet_gateway_common::trustees::bitcoin::BtcTrusteeMultisig<Test>,
         AccountId,
     >;
-    type Channel = XGatewayCommon;
-    type AddrBinding = XGatewayCommon;
+    type ReferralBinding = XGatewayCommon;
+    type AddressBinding = XGatewayCommon;
     type WeightInfo = ();
 }
 

--- a/xpallets/gateway/common/src/benchmarking.rs
+++ b/xpallets/gateway/common/src/benchmarking.rs
@@ -155,7 +155,7 @@ benchmarks! {
         let who_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(who.clone());
     }: _(RawOrigin::Root, Chain::Bitcoin, who_lookup.clone(), who_lookup.clone())
     verify {
-        assert_eq!(Module::<T>::channel_binding_of(&who, Chain::Bitcoin), Some(who));
+        assert_eq!(Module::<T>::referral_binding_of(&who, Chain::Bitcoin), Some(who));
     }
 }
 

--- a/xpallets/gateway/common/src/mock.rs
+++ b/xpallets/gateway/common/src/mock.rs
@@ -135,8 +135,8 @@ impl xpallet_gateway_bitcoin::Trait for Test {
     type AccountExtractor = ();
     type TrusteeSessionProvider = ();
     type TrusteeOrigin = EnsureSignedBy<BtcTrusteeMultisig<Test>, AccountId>;
-    type Channel = ();
-    type AddrBinding = ();
+    type ReferralBinding = ();
+    type AddressBinding = ();
     type WeightInfo = ();
 }
 

--- a/xpallets/gateway/common/src/traits.rs
+++ b/xpallets/gateway/common/src/traits.rs
@@ -9,7 +9,6 @@ use xpallet_assets::Chain;
 use crate::types::{TrusteeInfoConfig, TrusteeIntentionProps, TrusteeSessionInfo};
 
 pub trait BytesLike: Into<Vec<u8>> + TryFrom<Vec<u8>> {}
-
 impl<T: Into<Vec<u8>> + TryFrom<Vec<u8>>> BytesLike for T {}
 
 pub trait ChainProvider {
@@ -60,26 +59,26 @@ impl<AccountId, TrusteeAddress: BytesLike> TrusteeSession<AccountId, TrusteeAddr
     fn genesis_trustee(_: Chain, _: &[AccountId]) {}
 }
 
-pub trait ChannelBinding<AccountId> {
-    fn update_binding(asset_id: &AssetId, who: &AccountId, channel_name: Option<ReferralId>);
-    fn get_binding_info(asset_id: &AssetId, who: &AccountId) -> Option<AccountId>;
+pub trait ReferralBinding<AccountId> {
+    fn update_binding(asset_id: &AssetId, who: &AccountId, referral_name: Option<ReferralId>);
+    fn referral(asset_id: &AssetId, who: &AccountId) -> Option<AccountId>;
 }
 
-impl<AccountId> ChannelBinding<AccountId> for () {
+impl<AccountId> ReferralBinding<AccountId> for () {
     fn update_binding(_: &AssetId, _: &AccountId, _: Option<ReferralId>) {}
-    fn get_binding_info(_: &AssetId, _: &AccountId) -> Option<AccountId> {
+    fn referral(_: &AssetId, _: &AccountId) -> Option<AccountId> {
         None
     }
 }
 
-pub trait AddrBinding<AccountId, Addr: Into<Vec<u8>>> {
-    fn update_binding(chain: Chain, addr: Addr, who: AccountId);
-    fn get_binding(chain: Chain, addr: Addr) -> Option<AccountId>;
+pub trait AddressBinding<AccountId, Address: Into<Vec<u8>>> {
+    fn update_binding(chain: Chain, address: Address, who: AccountId);
+    fn address(chain: Chain, address: Address) -> Option<AccountId>;
 }
 
-impl<AccountId, Addr: Into<Vec<u8>>> AddrBinding<AccountId, Addr> for () {
-    fn update_binding(_: Chain, _: Addr, _: AccountId) {}
-    fn get_binding(_: Chain, _: Addr) -> Option<AccountId> {
+impl<AccountId, Address: Into<Vec<u8>>> AddressBinding<AccountId, Address> for () {
+    fn update_binding(_: Chain, _: Address, _: AccountId) {}
+    fn address(_: Chain, _: Address) -> Option<AccountId> {
         None
     }
 }


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

* Rename `ChannelBinding/AddrBinding` trait to `ReferralBinding/AddressBinding`
* **Rename storage**:
  * rename `AddressBinding` (does not exist) to `AddressBindingOf`
  * rename `ChannelBindingOf` (does not exist)  to `ReferralBindingOf`