### PR TITLE
use 0 replace return Error in sign script check

### DIFF
--- a/xpallets/gateway/bitcoin/src/tx/validator.rs
+++ b/xpallets/gateway/bitcoin/src/tx/validator.rs
@@ -82,7 +82,8 @@ pub fn parse_and_check_signed_tx_impl<T: Trait>(
         let script: Script = tx.inputs[i].script_sig.clone().into();
         if script.len() < 2 {
             // if script length less than 2, it must has no sig in input, use 0 to represent it
-            return Err(Error::<T>::InvalidSignCount.into());
+            input_signs.push(0);
+            continue;
         }
         let (sigs, _) = script
             .extract_multi_scriptsig()


### PR DESCRIPTION
in chainx 1.0, the script check is just use 0, not return error. But in 2.0 I use Error to return directly. However this cause create_withdraw_tx could not create an empty sign tx. Thus, we recover this part to push a zero in result, not return Error directly.