### PR TITLE
Reset malan

### DIFF
--- a/runtime/malan/src/constants.rs
+++ b/runtime/malan/src/constants.rs
@@ -22,7 +22,7 @@ pub mod time {
 
     pub const MILLISECS_PER_BLOCK: Moment = 6000;
     pub const SLOT_DURATION: Moment = MILLISECS_PER_BLOCK;
-    pub const EPOCH_DURATION_IN_BLOCKS: BlockNumber = 5 * MINUTES;
+    pub const EPOCH_DURATION_IN_BLOCKS: BlockNumber = 7 * DAYS;
 
     // These time units are defined in number of blocks.
     pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);


### PR DESCRIPTION
The testnet malan was broken and basically unrecoverable before, thus it had  been reset and `EPOCH_DURATION_IN_BLOCKS` is changed to 7 DAYS now.