### PR TITLE
Add two new asset for chainx bridge 

### DIFF
--- a/cli/src/chain_spec.rs
+++ b/cli/src/chain_spec.rs
@@ -20,7 +20,7 @@ use chainx_primitives::{AccountId, AssetId, Balance, ReferralId, Signature};
 use chainx_runtime::constants::currency::DOLLARS;
 use dev_runtime::constants::{currency::DOLLARS as DEV_DOLLARS, time::DAYS as DEV_DAYS};
 use xp_assets_registrar::Chain;
-use xp_protocol::{NetworkType, E_BTC, PCX, PCX_DECIMALS, S_BTC, X_BTC};
+use xp_protocol::{NetworkType, C_BTC, PCX, PCX_DECIMALS, S_BTC, X_BTC};
 use xpallet_gateway_bitcoin::{BtcParams, BtcTxVerifier};
 use xpallet_gateway_bitcoin_v2::types::TradingPrice;
 use xpallet_gateway_common::types::TrusteeInfoConfig;
@@ -435,7 +435,7 @@ fn build_genesis(
         }),
         xpallet_mining_asset: Some(dev::XMiningAssetConfig {
             claim_restrictions: vec![(X_BTC, (10, DEV_DAYS * 7))],
-            mining_power_map: vec![(X_BTC, 400), (E_BTC, 360), (S_BTC, 40)],
+            mining_power_map: vec![(X_BTC, 400), (C_BTC, 360), (S_BTC, 40)],
         }),
         xpallet_dex_spot: Some(dev::XSpotConfig {
             trading_pairs: vec![(PCX, X_BTC, 9, 2, 100000, true)],

--- a/cli/src/chain_spec.rs
+++ b/cli/src/chain_spec.rs
@@ -20,7 +20,7 @@ use chainx_primitives::{AccountId, AssetId, Balance, ReferralId, Signature};
 use chainx_runtime::constants::currency::DOLLARS;
 use dev_runtime::constants::{currency::DOLLARS as DEV_DOLLARS, time::DAYS as DEV_DAYS};
 use xp_assets_registrar::Chain;
-use xp_protocol::{NetworkType, PCX, PCX_DECIMALS, X_BTC};
+use xp_protocol::{NetworkType, E_BTC, PCX, PCX_DECIMALS, S_BTC, X_BTC};
 use xpallet_gateway_bitcoin::{BtcParams, BtcTxVerifier};
 use xpallet_gateway_bitcoin_v2::types::TradingPrice;
 use xpallet_gateway_common::types::TrusteeInfoConfig;
@@ -435,7 +435,7 @@ fn build_genesis(
         }),
         xpallet_mining_asset: Some(dev::XMiningAssetConfig {
             claim_restrictions: vec![(X_BTC, (10, DEV_DAYS * 7))],
-            mining_power_map: vec![(X_BTC, 400)],
+            mining_power_map: vec![(X_BTC, 400), (E_BTC, 360), (S_BTC, 40)],
         }),
         xpallet_dex_spot: Some(dev::XSpotConfig {
             trading_pairs: vec![(PCX, X_BTC, 9, 2, 100000, true)],

--- a/cli/src/genesis/assets.rs
+++ b/cli/src/genesis/assets.rs
@@ -1,6 +1,6 @@
 // Copyright 2019-2020 ChainX Project Authors. Licensed under GPL-3.0.
 
-use xp_protocol::{BTC_DECIMALS, PCX, PCX_DECIMALS, X_BTC};
+use xp_protocol::{BTC_DECIMALS, E_BTC, PCX, PCX_DECIMALS, S_BTC, X_BTC};
 
 use chainx_runtime::{AssetId, AssetInfo, AssetRestrictions, Chain, Runtime};
 
@@ -53,14 +53,46 @@ pub(crate) fn xbtc() -> (AssetId, AssetInfo, AssetRestrictions) {
         AssetRestrictions::DESTROY_USABLE,
     )
 }
+pub(crate) fn ebtc() -> (AssetId, AssetInfo, AssetRestrictions) {
+    (
+        E_BTC,
+        AssetInfo::new::<Runtime>(
+            b"EBTC".to_vec(),
+            b"ChainX Bitcoin from chainx bridge".to_vec(),
+            Chain::Bitcoin,
+            BTC_DECIMALS,
+            b"ChainX Bridge's Cross-chain Bitcoin".to_vec(),
+        )
+        .unwrap(),
+        AssetRestrictions::DESTROY_USABLE,
+    )
+}
+pub(crate) fn sbtc() -> (AssetId, AssetInfo, AssetRestrictions) {
+    (
+        S_BTC,
+        AssetInfo::new::<Runtime>(
+            b"XBTC".to_vec(),
+            b"ChainX Bitcoin".to_vec(),
+            Chain::Bitcoin,
+            BTC_DECIMALS,
+            b"ChainX's Cross-chain Bitcoin".to_vec(),
+        )
+        .unwrap(),
+        AssetRestrictions::empty(),
+    )
+}
 
 // asset_id, asset_info, asset_restrictions, is_online, has_mining_rights
 pub(crate) fn genesis_assets() -> Vec<(AssetId, AssetInfo, AssetRestrictions, bool, bool)> {
     let pcx = pcx();
     let btc = xbtc();
+    let ebtc = ebtc();
+    let sbtc = sbtc();
     let assets = vec![
         (pcx.0, pcx.1, pcx.2, true, false),
         (btc.0, btc.1, btc.2, true, true),
+        (ebtc.0, ebtc.1, ebtc.2, true, true),
+        (sbtc.0, sbtc.1, sbtc.2, true, true),
     ];
     assets
 }

--- a/cli/src/genesis/assets.rs
+++ b/cli/src/genesis/assets.rs
@@ -53,11 +53,11 @@ pub(crate) fn xbtc() -> (AssetId, AssetInfo, AssetRestrictions) {
         AssetRestrictions::DESTROY_USABLE,
     )
 }
-pub(crate) fn ebtc() -> (AssetId, AssetInfo, AssetRestrictions) {
+pub(crate) fn cbtc() -> (AssetId, AssetInfo, AssetRestrictions) {
     (
         C_BTC,
         AssetInfo::new::<Runtime>(
-            b"EBTC".to_vec(),
+            b"CBTC".to_vec(),
             b"ChainX Bitcoin from chainx bridge".to_vec(),
             Chain::Bitcoin,
             BTC_DECIMALS,
@@ -71,11 +71,11 @@ pub(crate) fn sbtc() -> (AssetId, AssetInfo, AssetRestrictions) {
     (
         S_BTC,
         AssetInfo::new::<Runtime>(
-            b"XBTC".to_vec(),
+            b"SBTC".to_vec(),
             b"ChainX Bitcoin".to_vec(),
             Chain::Bitcoin,
             BTC_DECIMALS,
-            b"ChainX's Cross-chain Bitcoin".to_vec(),
+            b"Shadow coin of C_BTC".to_vec(),
         )
         .unwrap(),
         AssetRestrictions::empty(),
@@ -86,12 +86,12 @@ pub(crate) fn sbtc() -> (AssetId, AssetInfo, AssetRestrictions) {
 pub(crate) fn genesis_assets() -> Vec<(AssetId, AssetInfo, AssetRestrictions, bool, bool)> {
     let pcx = pcx();
     let btc = xbtc();
-    let ebtc = ebtc();
+    let cbtc = cbtc();
     let sbtc = sbtc();
     let assets = vec![
         (pcx.0, pcx.1, pcx.2, true, false),
         (btc.0, btc.1, btc.2, true, true),
-        (ebtc.0, ebtc.1, ebtc.2, true, true),
+        (cbtc.0, cbtc.1, cbtc.2, true, true),
         (sbtc.0, sbtc.1, sbtc.2, true, true),
     ];
     assets

--- a/cli/src/genesis/assets.rs
+++ b/cli/src/genesis/assets.rs
@@ -1,6 +1,6 @@
 // Copyright 2019-2020 ChainX Project Authors. Licensed under GPL-3.0.
 
-use xp_protocol::{BTC_DECIMALS, E_BTC, PCX, PCX_DECIMALS, S_BTC, X_BTC};
+use xp_protocol::{BTC_DECIMALS, C_BTC, PCX, PCX_DECIMALS, S_BTC, X_BTC};
 
 use chainx_runtime::{AssetId, AssetInfo, AssetRestrictions, Chain, Runtime};
 
@@ -55,7 +55,7 @@ pub(crate) fn xbtc() -> (AssetId, AssetInfo, AssetRestrictions) {
 }
 pub(crate) fn ebtc() -> (AssetId, AssetInfo, AssetRestrictions) {
     (
-        E_BTC,
+        C_BTC,
         AssetInfo::new::<Runtime>(
             b"EBTC".to_vec(),
             b"ChainX Bitcoin from chainx bridge".to_vec(),

--- a/primitives/protocol/src/asset.rs
+++ b/primitives/protocol/src/asset.rs
@@ -25,7 +25,7 @@ use chainx_primitives::{AssetId, Decimals};
 //      ChainX would derived some special token which just on ChainX and it is not real cross
 //      assets but also have some relationship to source chain assets. Thus we use some
 //      particular prefix to distinguish with base token.
-//      (e.g. L_BTC means locked bitcoin, S_DOT means shadow DOT, E_BTC means experimental BTC)
+//      (e.g. L_BTC means locked bitcoin, S_DOT means shadow DOT, C_BTC means collateral based BTC)
 //      to distinguish with base token AssetId, we use `<Some Prefix>|<base token AssetId>` to
 //      express the derived token. Different derived situation have different prefix.
 //      thus we agree on the prefix:
@@ -45,8 +45,8 @@ pub const BTC_DECIMALS: Decimals = 8;
 /// Reserved since this symbol had been used in legacy ChainX 1.0.
 pub const L_BTC: AssetId = 0x90000000 | X_BTC;
 /// Experimental BTC for early access version feature, to avoid it mess up the legacy feature
-pub const E_BTC: AssetId = 0xc0000000 | X_BTC;
-/// Shadow token for E_BTC
+pub const C_BTC: AssetId = 0xc0000000 | X_BTC;
+/// Shadow token for C_BTC
 pub const S_BTC: AssetId = 0xa0000000 | X_BTC;
 
 /// ETH asset in ChainX backed by the Mainnet Ethereum.

--- a/primitives/protocol/src/asset.rs
+++ b/primitives/protocol/src/asset.rs
@@ -25,12 +25,13 @@ use chainx_primitives::{AssetId, Decimals};
 //      ChainX would derived some special token which just on ChainX and it is not real cross
 //      assets but also have some relationship to source chain assets. Thus we use some
 //      particular prefix to distinguish with base token.
-//      (e.g. L_BTC means locked bitcoin, S_DOT means shadow DOT)
+//      (e.g. L_BTC means locked bitcoin, S_DOT means shadow DOT, E_BTC means experimental BTC)
 //      to distinguish with base token AssetId, we use `<Some Prefix>|<base token AssetId>` to
 //      express the derived token. Different derived situation have different prefix.
 //      thus we agree on the prefix:
 //      L_: use 0x90000000
 //      S_: use 0xa0000000
+//      E_: use 0xc0000000
 
 /// Native asset of ChainX.
 pub const PCX: AssetId = 0;
@@ -43,6 +44,10 @@ pub const X_BTC: AssetId = 1;
 pub const BTC_DECIMALS: Decimals = 8;
 /// Reserved since this symbol had been used in legacy ChainX 1.0.
 pub const L_BTC: AssetId = 0x90000000 | X_BTC;
+/// Experimental BTC for early access version feature, to avoid it mess up the legacy feature
+pub const E_BTC: AssetId = 0xc0000000 | X_BTC;
+/// Shadow token for E_BTC
+pub const S_BTC: AssetId = 0xa0000000 | X_BTC;
 
 /// ETH asset in ChainX backed by the Mainnet Ethereum.
 pub const X_ETH: AssetId = 60;

--- a/runtime/chainx/src/lib.rs
+++ b/runtime/chainx/src/lib.rs
@@ -980,7 +980,7 @@ impl xpallet_gateway_bitcoin::Config for Runtime {
 }
 
 parameter_types! {
-    pub const BridgeTargetAssetId: u32 = E_BTC;
+    pub const BridgeTargetAssetId: u32 = C_BTC;
     pub const BridgeTokenAssetId: u32 = S_BTC;
     pub const DustCollateral: Balance = 1000;
     pub const SecureThreshold: u16 = 300;

--- a/runtime/chainx/src/lib.rs
+++ b/runtime/chainx/src/lib.rs
@@ -980,7 +980,8 @@ impl xpallet_gateway_bitcoin::Config for Runtime {
 }
 
 parameter_types! {
-    pub const BridgeTargetAssetId: u8 = 1;
+    pub const BridgeTargetAssetId: u32 = E_BTC;
+    pub const BridgeTokenAssetId: u32 = S_BTC;
     pub const DustCollateral: Balance = 1000;
     pub const SecureThreshold: u16 = 300;
     pub const PremiumThreshold: u16 = 250;
@@ -994,6 +995,7 @@ parameter_types! {
 impl xpallet_gateway_bitcoin_v2_pallet::Config for Runtime {
     type Event = Event;
     type TargetAssetId = BridgeTargetAssetId;
+    type TokenAssetId = BridgeTokenAssetId;
     type DustCollateral = DustCollateral;
     type SecureThreshold = SecureThreshold;
     type PremiumThreshold = PremiumThreshold;

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -439,7 +439,8 @@ impl pallet_session_historical::Config for Runtime {
 }
 
 parameter_types! {
-    pub const BridgeTargetAssetId: u8 = 1;
+    pub const BridgeTargetAssetId: u32 = E_BTC;
+    pub const BridgeTokenAssetId: u32 = S_BTC;
     pub const DustCollateral: Balance = 1000;
     pub const SecureThreshold: u16 = 300;
     pub const PremiumThreshold: u16 = 250;
@@ -453,6 +454,7 @@ parameter_types! {
 impl xpallet_gateway_bitcoin_v2_pallet::Config for Runtime {
     type Event = Event;
     type TargetAssetId = BridgeTargetAssetId;
+    type TokenAssetId = BridgeTokenAssetId;
     type DustCollateral = DustCollateral;
     type SecureThreshold = SecureThreshold;
     type PremiumThreshold = PremiumThreshold;

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -439,7 +439,7 @@ impl pallet_session_historical::Config for Runtime {
 }
 
 parameter_types! {
-    pub const BridgeTargetAssetId: u32 = E_BTC;
+    pub const BridgeTargetAssetId: u32 = C_BTC;
     pub const BridgeTokenAssetId: u32 = S_BTC;
     pub const DustCollateral: Balance = 1000;
     pub const SecureThreshold: u16 = 300;

--- a/runtime/malan/src/lib.rs
+++ b/runtime/malan/src/lib.rs
@@ -984,7 +984,7 @@ impl xpallet_gateway_bitcoin::Config for Runtime {
 }
 
 parameter_types! {
-    pub const BridgeTargetAssetId: u32 = E_BTC;
+    pub const BridgeTargetAssetId: u32 = C_BTC;
     pub const BridgeTokenAssetId: u32 = S_BTC;
     pub const DustCollateral: Balance = 1000;
     pub const SecureThreshold: u16 = 300;

--- a/runtime/malan/src/lib.rs
+++ b/runtime/malan/src/lib.rs
@@ -984,7 +984,8 @@ impl xpallet_gateway_bitcoin::Config for Runtime {
 }
 
 parameter_types! {
-    pub const BridgeTargetAssetId: u8 = 1;
+    pub const BridgeTargetAssetId: u32 = E_BTC;
+    pub const BridgeTokenAssetId: u32 = S_BTC;
     pub const DustCollateral: Balance = 1000;
     pub const SecureThreshold: u16 = 300;
     pub const PremiumThreshold: u16 = 250;
@@ -998,6 +999,7 @@ parameter_types! {
 impl xpallet_gateway_bitcoin_v2_pallet::Config for Runtime {
     type Event = Event;
     type TargetAssetId = BridgeTargetAssetId;
+    type TokenAssetId = BridgeTokenAssetId;
     type DustCollateral = DustCollateral;
     type SecureThreshold = SecureThreshold;
     type PremiumThreshold = PremiumThreshold;

--- a/xpallets/assets/src/lib.rs
+++ b/xpallets/assets/src/lib.rs
@@ -243,7 +243,10 @@ decl_module! {
 
 // others
 impl<T: Config> Module<T> {
-    fn set_asset_restrictions(
+    /// Set asset restrictions
+    ///
+    /// Forbidden some operations for target asset
+    pub fn set_asset_restrictions(
         asset_id: AssetId,
         restrictions: AssetRestrictions,
     ) -> DispatchResult {

--- a/xpallets/gateway/bitcoin/v2/src/mock.rs
+++ b/xpallets/gateway/bitcoin/v2/src/mock.rs
@@ -75,7 +75,8 @@ impl xpallet_assets::Config for Test {
 }
 
 parameter_types! {
-    pub const BridgeTargetAssetId: u32 = 1;
+    pub const BridgeTargetAssetId: u32 = xp_protocol::E_BTC;
+    pub const BridgeTokenAssetId: u32 = xp_protocol::S_BTC;
     pub const DustCollateral: Balance = 1000;
     pub const SecureThreshold: u16 = 300;
     pub const PremiumThreshold: u16 = 250;
@@ -89,6 +90,7 @@ parameter_types! {
 impl pallet::Config for Test {
     type Event = ();
     type TargetAssetId = BridgeTargetAssetId;
+    type TokenAssetId = BridgeTokenAssetId;
     type DustCollateral = DustCollateral;
     type SecureThreshold = SecureThreshold;
     type PremiumThreshold = PremiumThreshold;

--- a/xpallets/gateway/bitcoin/v2/src/mock.rs
+++ b/xpallets/gateway/bitcoin/v2/src/mock.rs
@@ -75,7 +75,7 @@ impl xpallet_assets::Config for Test {
 }
 
 parameter_types! {
-    pub const BridgeTargetAssetId: u32 = xp_protocol::E_BTC;
+    pub const BridgeTargetAssetId: u32 = xp_protocol::C_BTC;
     pub const BridgeTokenAssetId: u32 = xp_protocol::S_BTC;
     pub const DustCollateral: Balance = 1000;
     pub const SecureThreshold: u16 = 300;

--- a/xpallets/gateway/bitcoin/v2/src/tests.rs
+++ b/xpallets/gateway/bitcoin/v2/src/tests.rs
@@ -44,7 +44,7 @@ fn t_register_btc() -> DispatchResult {
             xpallet_assets::AssetRestrictions::empty(),
         ),
         (
-            xp_protocol::E_BTC,
+            xp_protocol::C_BTC,
             xpallet_assets_registrar::AssetInfo::new::<Test>(
                 b"E-BTC".to_vec(),
                 b"E-BTC".to_vec(),

--- a/xpallets/gateway/bitcoin/v2/src/tests.rs
+++ b/xpallets/gateway/bitcoin/v2/src/tests.rs
@@ -46,11 +46,11 @@ fn t_register_btc() -> DispatchResult {
         (
             xp_protocol::C_BTC,
             xpallet_assets_registrar::AssetInfo::new::<Test>(
-                b"E-BTC".to_vec(),
-                b"E-BTC".to_vec(),
+                b"C-BTC".to_vec(),
+                b"C-BTC".to_vec(),
                 xpallet_assets_registrar::Chain::Bitcoin,
                 xp_protocol::BTC_DECIMALS,
-                b"ChainX's cross-chain Bitcoin".to_vec(),
+                b"Bridge ChainX's cross-chain Bitcoin".to_vec(),
             )
             .unwrap(),
             xpallet_assets::AssetRestrictions::empty(),
@@ -62,7 +62,7 @@ fn t_register_btc() -> DispatchResult {
                 b"S-BTC".to_vec(),
                 xpallet_assets_registrar::Chain::Bitcoin,
                 xp_protocol::BTC_DECIMALS,
-                b"ChainX's cross-chain Bitcoin".to_vec(),
+                b"Shadow token of C-BTC".to_vec(),
             )
             .unwrap(),
             xpallet_assets::AssetRestrictions::empty(),

--- a/xpallets/gateway/bitcoin/v2/src/types.rs
+++ b/xpallets/gateway/bitcoin/v2/src/types.rs
@@ -1,9 +1,9 @@
 use sp_std::vec::Vec;
 
-use bitflags::bitflags;
 use codec::{Decode, Encode};
-use sp_runtime::RuntimeDebug;
+use sp_runtime::{traits::AtLeast32BitUnsigned, RuntimeDebug};
 
+use bitflags::bitflags;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 
@@ -102,7 +102,6 @@ impl Default for VaultStatus {
 pub struct SystemVault<AccountId, Balance> {
     pub(crate) id: AccountId,
     pub(crate) to_be_issued_tokens: Balance,
-    pub(crate) issued_tokens: Balance,
     pub(crate) to_be_redeemed_tokens: Balance,
 }
 
@@ -110,13 +109,9 @@ pub struct SystemVault<AccountId, Balance> {
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "std", derive(Debug))]
-pub struct Vault<AccountId, BlockNumber, Balance> {
-    /// Account identifier of the Vault
-    pub id: AccountId,
+pub struct Vault<BlockNumber, Balance> {
     /// Number of tokens pending issue
     pub to_be_issued_tokens: Balance,
-    /// Number of issued tokens
-    pub issued_tokens: Balance,
     /// Number of tokens pending redeem
     pub to_be_redeemed_tokens: Balance,
     /// Bitcoin address of this Vault (P2PKH, P2SH, P2PKH, P2WSH)
@@ -128,12 +123,9 @@ pub struct Vault<AccountId, BlockNumber, Balance> {
     pub status: VaultStatus,
 }
 
-impl<AccountId: Default, BlockNumber: Default, Balance: Default>
-    Vault<AccountId, BlockNumber, Balance>
-{
-    pub(crate) fn new(id: AccountId, address: BtcAddress) -> Self {
+impl<BlockNumber: Default, Balance: Default> Vault<BlockNumber, Balance> {
+    pub(crate) fn new(address: BtcAddress) -> Self {
         Self {
-            id,
             wallet: address,
             ..Default::default()
         }


### PR DESCRIPTION
Register two new assets.
- C_BTC: collateral based BTC in ChainX, it should be only used in testnet to avoid messed up with XBTC.
- S_BTC: Shadow token of E_BTC. Shadow token is the proof of interests and limited to move operation(not implement yet).
Mining Power for E_BTC: S_BTC is 360: 40, where XBTC is 400.

Refactor code in `xpallet_gateway_bitcoin_v2`(current official named as `chainx-bridge(for btc)`)
- remove liquidating part due to unresolved problem.
- remove `issued_token` and `id` fields in `Vault`
- refactor unit tests