### PR TITLE
Change signature for `parse_transaction`

### DIFF
--- a/primitives/gateway/bitcoin/src/types.rs
+++ b/primitives/gateway/bitcoin/src/types.rs
@@ -10,6 +10,9 @@ use chainx_primitives::ReferralId;
 
 use light_bitcoin::keys::Address;
 
+/// (hot trustee address, cold trustee address)
+pub type TrusteePair = (Address, Address);
+
 /// The bitcoin transaction type.
 #[doc(hidden)]
 #[derive(PartialEq, Eq, Clone, Copy, Encode, Decode, RuntimeDebug)]

--- a/xpallets/gateway/bitcoin/v1/src/tests/tx.rs
+++ b/xpallets/gateway/bitcoin/v1/src/tests/tx.rs
@@ -99,18 +99,18 @@ fn mock_detect_transaction_type<T: Config>(
     tx: &Transaction,
     prev_tx: Option<&Transaction>,
 ) -> BtcTxMetaType<T::AccountId> {
-    let btc_tx_detector = BtcTxTypeDetector::new(
-        Network::Mainnet,
-        0,
-        (
-            DEPOSIT_HOT_ADDR.parse::<Address>().unwrap(),
-            DEPOSIT_COLD_ADDR.parse::<Address>().unwrap(),
-        ),
-        None,
+    let btc_tx_detector = BtcTxTypeDetector::new(Network::Mainnet, 0);
+    let current_trustee_pair = (
+        DEPOSIT_HOT_ADDR.parse::<Address>().unwrap(),
+        DEPOSIT_COLD_ADDR.parse::<Address>().unwrap(),
     );
-    btc_tx_detector.detect_transaction_type::<T::AccountId, _>(tx, prev_tx, |script| {
-        T::AccountExtractor::extract_account(script)
-    })
+    btc_tx_detector.detect_transaction_type::<T::AccountId, _>(
+        tx,
+        prev_tx,
+        |script| T::AccountExtractor::extract_account(script),
+        current_trustee_pair,
+        None,
+    )
 }
 
 #[test]

--- a/xpallets/gateway/bitcoin/v1/src/tx/mod.rs
+++ b/xpallets/gateway/bitcoin/v1/src/tx/mod.rs
@@ -36,16 +36,13 @@ pub fn process_tx<T: Config>(
     current_trustee_pair: (Address, Address),
     last_trustee_pair: Option<(Address, Address)>,
 ) -> BtcTxState {
-    let btc_tx_detector = BtcTxTypeDetector::new(
-        network,
-        min_deposit,
-        current_trustee_pair,
-        last_trustee_pair,
-    );
+    let btc_tx_detector = BtcTxTypeDetector::new(network, min_deposit);
     let meta_type = btc_tx_detector.detect_transaction_type::<T::AccountId, _>(
         &tx,
         prev_tx.as_ref(),
         T::AccountExtractor::extract_account,
+        current_trustee_pair,
+        last_trustee_pair,
     );
 
     let tx_type = meta_type.ref_into();


### PR DESCRIPTION
Forward trustee pair as parameters rather than fields in `BtcTxDetector`.