### PR TITLE
Use `MultiAddress`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3678,7 +3678,7 @@ dependencies = [
 [[package]]
 name = "light-bitcoin"
 version = "0.2.0"
-source = "git+https://github.com/chainx-org/light-bitcoin?branch=btc-like#5ec9b441cd3bdd08256577386e4231118fe24b99"
+source = "git+https://github.com/chainx-org/light-bitcoin?branch=btc-like#443180fd013d2a97340c33fd24647c8efe417acb"
 dependencies = [
  "light-bitcoin-chain",
  "light-bitcoin-crypto",
@@ -3692,7 +3692,7 @@ dependencies = [
 [[package]]
 name = "light-bitcoin-chain"
 version = "0.2.0"
-source = "git+https://github.com/chainx-org/light-bitcoin?branch=btc-like#5ec9b441cd3bdd08256577386e4231118fe24b99"
+source = "git+https://github.com/chainx-org/light-bitcoin?branch=btc-like#443180fd013d2a97340c33fd24647c8efe417acb"
 dependencies = [
  "hex",
  "light-bitcoin-crypto",
@@ -3705,7 +3705,7 @@ dependencies = [
 [[package]]
 name = "light-bitcoin-crypto"
 version = "0.2.0"
-source = "git+https://github.com/chainx-org/light-bitcoin?branch=btc-like#5ec9b441cd3bdd08256577386e4231118fe24b99"
+source = "git+https://github.com/chainx-org/light-bitcoin?branch=btc-like#443180fd013d2a97340c33fd24647c8efe417acb"
 dependencies = [
  "digest 0.9.0",
  "light-bitcoin-primitives",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "light-bitcoin-keys"
 version = "0.2.0"
-source = "git+https://github.com/chainx-org/light-bitcoin?branch=btc-like#5ec9b441cd3bdd08256577386e4231118fe24b99"
+source = "git+https://github.com/chainx-org/light-bitcoin?branch=btc-like#443180fd013d2a97340c33fd24647c8efe417acb"
 dependencies = [
  "bs58 0.4.0",
  "hex",
@@ -3733,7 +3733,7 @@ dependencies = [
 [[package]]
 name = "light-bitcoin-merkle"
 version = "0.2.0"
-source = "git+https://github.com/chainx-org/light-bitcoin?branch=btc-like#5ec9b441cd3bdd08256577386e4231118fe24b99"
+source = "git+https://github.com/chainx-org/light-bitcoin?branch=btc-like#443180fd013d2a97340c33fd24647c8efe417acb"
 dependencies = [
  "light-bitcoin-chain",
  "light-bitcoin-primitives",
@@ -3744,7 +3744,7 @@ dependencies = [
 [[package]]
 name = "light-bitcoin-primitives"
 version = "0.2.0"
-source = "git+https://github.com/chainx-org/light-bitcoin?branch=btc-like#5ec9b441cd3bdd08256577386e4231118fe24b99"
+source = "git+https://github.com/chainx-org/light-bitcoin?branch=btc-like#443180fd013d2a97340c33fd24647c8efe417acb"
 dependencies = [
  "byteorder",
  "fixed-hash",
@@ -3758,7 +3758,7 @@ dependencies = [
 [[package]]
 name = "light-bitcoin-script"
 version = "0.2.0"
-source = "git+https://github.com/chainx-org/light-bitcoin?branch=btc-like#5ec9b441cd3bdd08256577386e4231118fe24b99"
+source = "git+https://github.com/chainx-org/light-bitcoin?branch=btc-like#443180fd013d2a97340c33fd24647c8efe417acb"
 dependencies = [
  "hex",
  "light-bitcoin-chain",
@@ -3771,7 +3771,7 @@ dependencies = [
 [[package]]
 name = "light-bitcoin-serialization"
 version = "0.2.0"
-source = "git+https://github.com/chainx-org/light-bitcoin?branch=btc-like#5ec9b441cd3bdd08256577386e4231118fe24b99"
+source = "git+https://github.com/chainx-org/light-bitcoin?branch=btc-like#443180fd013d2a97340c33fd24647c8efe417acb"
 dependencies = [
  "light-bitcoin-primitives",
  "light-bitcoin-serialization-derive",
@@ -3780,7 +3780,7 @@ dependencies = [
 [[package]]
 name = "light-bitcoin-serialization-derive"
 version = "0.2.0"
-source = "git+https://github.com/chainx-org/light-bitcoin?branch=btc-like#5ec9b441cd3bdd08256577386e4231118fe24b99"
+source = "git+https://github.com/chainx-org/light-bitcoin?branch=btc-like#443180fd013d2a97340c33fd24647c8efe417acb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8914,7 +8914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f8ab788026715fa63b31960869617cba39117e520eb415b0139543e325ab59"
 dependencies = [
  "cfg-if 0.1.10",
- "rand 0.7.3",
+ "rand 0.3.23",
  "static_assertions",
 ]
 

--- a/primitives/gateway/bitcoin/src/detector.rs
+++ b/primitives/gateway/bitcoin/src/detector.rs
@@ -7,7 +7,7 @@ use frame_support::log::{debug, warn};
 
 use light_bitcoin::{
     chain::Transaction,
-    keys::{Address, Network},
+    keys::{MultiAddress as Address, Network},
     primitives::hash_rev,
     script::Script,
 };
@@ -65,7 +65,7 @@ impl BtcTxTypeDetector {
             .first()
             .expect("Btc Transaction must have at least one output");
 
-        let output = extract_output_addr(output_info, self.network);
+        let output = extract_output_addr(output_info, self.network, None);
 
         if let Some(output) = output {
             //TODO(wangyafei): change `parse_deposit_transaction_outputs` signature from address
@@ -156,7 +156,7 @@ impl BtcTxTypeDetector {
             let all_outputs_is_trustee = tx
                 .outputs
                 .iter()
-                .map(|output| extract_output_addr(output, self.network).unwrap_or_default())
+                .map(|output| extract_output_addr(output, self.network, None).unwrap_or_default())
                 .all(|addr| is_trustee_addr(addr, current_trustee_pair));
 
             if is_trustee_addr(input_addr, current_trustee_pair) {
@@ -288,7 +288,7 @@ impl BtcTxTypeDetector {
         let (hot_addr, _) = current_trustee_pair;
         for output in &tx.outputs {
             // extract destination address from the script of output.
-            if let Some(dest_addr) = extract_output_addr(output, self.network) {
+            if let Some(dest_addr) = extract_output_addr(output, self.network, None) {
                 // check if the script address of the output is the hot trustee address
                 if dest_addr.hash == hot_addr.hash && output.value > 0 {
                     deposit_value += output.value;

--- a/primitives/gateway/bitcoin/src/types.rs
+++ b/primitives/gateway/bitcoin/src/types.rs
@@ -8,7 +8,7 @@ use sp_runtime::RuntimeDebug;
 
 use chainx_primitives::ReferralId;
 
-use light_bitcoin::keys::Address;
+use light_bitcoin::keys::MultiAddress as Address;
 
 /// (hot trustee address, cold trustee address)
 pub type TrusteePair = (Address, Address);

--- a/primitives/gateway/bitcoin/src/utils.rs
+++ b/primitives/gateway/bitcoin/src/utils.rs
@@ -6,7 +6,7 @@ use frame_support::log::{error, warn};
 
 use light_bitcoin::{
     chain::{Transaction, TransactionOutput},
-    keys::{Address, Network},
+    keys::{Chain, MultiAddress as Address, Network},
     script::{Opcode, Script, ScriptType},
 };
 
@@ -18,12 +18,16 @@ pub fn extract_addr_from_transaction(
 ) -> Option<Address> {
     tx.outputs
         .get(outpoint_index)
-        .and_then(|output| extract_output_addr(output, network))
+        .and_then(|output| extract_output_addr(output, network, None))
 }
 
 /// Extract address from a transaction output script.
 /// only support `p2pk`, `p2pkh` and `p2sh` output script
-pub fn extract_output_addr(output: &TransactionOutput, network: Network) -> Option<Address> {
+pub fn extract_output_addr(
+    output: &TransactionOutput,
+    network: Network,
+    chain: Option<Chain>,
+) -> Option<Address> {
     let script = Script::new(output.script_pubkey.clone());
 
     // only support `p2pk`, `p2pkh` and `p2sh` script
@@ -45,6 +49,7 @@ pub fn extract_output_addr(output: &TransactionOutput, network: Network) -> Opti
                     network,
                     kind: address.kind,
                     hash: address.hash,
+                    chain: chain.unwrap_or_default(),
                 })
             } else {
                 warn!(

--- a/runtime/chainx/src/lib.rs
+++ b/runtime/chainx/src/lib.rs
@@ -975,7 +975,7 @@ impl xpallet_gateway_bitcoin::Config for Runtime {
     type ReferralBinding = XGatewayCommon;
     type AddressBinding = XGatewayCommon;
     type WeightInfo = xpallet_gateway_bitcoin::weights::SubstrateWeight<Runtime>;
-    type ChainIdentity = xpallet_gateway_bitcoin::types::BtcChain;
+    type Chain = xpallet_gateway_bitcoin::types::BtcChain;
 }
 
 impl xpallet_dex_spot::Config for Runtime {

--- a/runtime/chainx/src/lib.rs
+++ b/runtime/chainx/src/lib.rs
@@ -975,6 +975,7 @@ impl xpallet_gateway_bitcoin::Config for Runtime {
     type ReferralBinding = XGatewayCommon;
     type AddressBinding = XGatewayCommon;
     type WeightInfo = xpallet_gateway_bitcoin::weights::SubstrateWeight<Runtime>;
+    type ChainIdentity = xpallet_gateway_bitcoin::types::BtcChain;
 }
 
 impl xpallet_dex_spot::Config for Runtime {

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -988,7 +988,7 @@ impl xpallet_gateway_bitcoin::Config for Runtime {
     type ReferralBinding = XGatewayCommon;
     type AddressBinding = XGatewayCommon;
     type WeightInfo = xpallet_gateway_bitcoin::weights::SubstrateWeight<Runtime>;
-    type ChainIdentity = xpallet_gateway_bitcoin::types::BtcChain;
+    type Chain = xpallet_gateway_bitcoin::types::BtcChain;
 }
 
 parameter_types! {

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -988,6 +988,7 @@ impl xpallet_gateway_bitcoin::Config for Runtime {
     type ReferralBinding = XGatewayCommon;
     type AddressBinding = XGatewayCommon;
     type WeightInfo = xpallet_gateway_bitcoin::weights::SubstrateWeight<Runtime>;
+    type ChainIdentity = xpallet_gateway_bitcoin::types::BtcChain;
 }
 
 parameter_types! {

--- a/runtime/malan/src/lib.rs
+++ b/runtime/malan/src/lib.rs
@@ -979,7 +979,7 @@ impl xpallet_gateway_bitcoin::Config for Runtime {
     type ReferralBinding = XGatewayCommon;
     type AddressBinding = XGatewayCommon;
     type WeightInfo = xpallet_gateway_bitcoin::weights::SubstrateWeight<Runtime>;
-    type ChainIdentity = xpallet_gateway_bitcoin::types::BtcChain;
+    type Chain = xpallet_gateway_bitcoin::types::BtcChain;
 }
 
 impl xpallet_dex_spot::Config for Runtime {

--- a/runtime/malan/src/lib.rs
+++ b/runtime/malan/src/lib.rs
@@ -979,6 +979,7 @@ impl xpallet_gateway_bitcoin::Config for Runtime {
     type ReferralBinding = XGatewayCommon;
     type AddressBinding = XGatewayCommon;
     type WeightInfo = xpallet_gateway_bitcoin::weights::SubstrateWeight<Runtime>;
+    type ChainIdentity = xpallet_gateway_bitcoin::types::BtcChain;
 }
 
 impl xpallet_dex_spot::Config for Runtime {

--- a/xpallets/gateway/bitcoin/v1/src/lib.rs
+++ b/xpallets/gateway/bitcoin/v1/src/lib.rs
@@ -100,7 +100,10 @@ pub mod pallet {
         type ReferralBinding: ReferralBinding<Self::AccountId>;
         type AddressBinding: AddressBinding<Self::AccountId, BtcAddress>;
         type WeightInfo: WeightInfo;
-        type ChainIdentity: Get<light_bitcoin::keys::Chain>;
+        /// Specify which chain we are dealing with, e.g., Bitcoin, Dogecoin.
+        ///
+        /// Required as now Bitcoin forks like Dogecoin are supported as well.
+        type Chain: Get<light_bitcoin::keys::Chain>;
     }
 
     #[pallet::hooks]

--- a/xpallets/gateway/bitcoin/v1/src/lib.rs
+++ b/xpallets/gateway/bitcoin/v1/src/lib.rs
@@ -7,7 +7,7 @@
 mod header;
 pub mod trustee;
 mod tx;
-mod types;
+pub mod types;
 pub mod weights;
 
 #[cfg(any(feature = "runtime-benchmarks", test))]
@@ -20,6 +20,11 @@ mod tests;
 use sp_runtime::SaturatedConversion;
 use sp_std::prelude::*;
 
+use frame_support::{
+    log::{debug, error, info},
+    traits::Get,
+};
+
 use orml_utilities::with_transaction_result;
 
 #[cfg(feature = "std")]
@@ -31,12 +36,11 @@ pub use light_bitcoin::{
 };
 use light_bitcoin::{
     chain::Transaction,
-    keys::{Address, DisplayLayout},
+    keys::{DisplayLayout, MultiAddress as Address},
     serialization::{deserialize, Reader},
 };
 
 use chainx_primitives::{AssetId, ReferralId};
-use frame_support::log::{debug, error, info};
 use xp_gateway_common::AccountExtractor;
 use xpallet_assets::{BalanceOf, Chain, ChainT, WithdrawalLimit};
 use xpallet_gateway_common::{
@@ -96,6 +100,7 @@ pub mod pallet {
         type ReferralBinding: ReferralBinding<Self::AccountId>;
         type AddressBinding: AddressBinding<Self::AccountId, BtcAddress>;
         type WeightInfo: WeightInfo;
+        type ChainIdentity: Get<light_bitcoin::keys::Chain>;
     }
 
     #[pallet::hooks]

--- a/xpallets/gateway/bitcoin/v1/src/mock.rs
+++ b/xpallets/gateway/bitcoin/v1/src/mock.rs
@@ -179,6 +179,7 @@ impl Config for Test {
     type ReferralBinding = XGatewayCommon;
     type AddressBinding = XGatewayCommon;
     type WeightInfo = ();
+    type ChainIdentity = crate::types::BtcChain;
 }
 
 pub type XGatewayBitcoinErr = Error<Test, ()>;

--- a/xpallets/gateway/bitcoin/v1/src/mock.rs
+++ b/xpallets/gateway/bitcoin/v1/src/mock.rs
@@ -179,7 +179,7 @@ impl Config for Test {
     type ReferralBinding = XGatewayCommon;
     type AddressBinding = XGatewayCommon;
     type WeightInfo = ();
-    type ChainIdentity = crate::types::BtcChain;
+    type Chain = crate::types::BtcChain;
 }
 
 pub type XGatewayBitcoinErr = Error<Test, ()>;

--- a/xpallets/gateway/bitcoin/v1/src/tests/tx.rs
+++ b/xpallets/gateway/bitcoin/v1/src/tests/tx.rs
@@ -7,7 +7,7 @@ use sp_core::crypto::{set_default_ss58_version, Ss58AddressFormat};
 
 use light_bitcoin::{
     chain::Transaction,
-    keys::{Address, Network},
+    keys::{MultiAddress as Address, Network},
     merkle::PartialMerkleTree,
     serialization::{self, Reader},
 };

--- a/xpallets/gateway/bitcoin/v1/src/trustee.rs
+++ b/xpallets/gateway/bitcoin/v1/src/trustee.rs
@@ -492,7 +492,7 @@ pub(crate) fn create_multi_address<T: Config<I>, I: 'static>(
         kind: Type::P2SH,
         network: Pallet::<T, I>::network_id(),
         hash: dhash160(&redeem_script),
-        chain: T::ChainIdentity::get(),
+        chain: T::Chain::get(),
     };
     let script_bytes: Bytes = redeem_script.into();
     Some(BtcTrusteeAddrInfo {

--- a/xpallets/gateway/bitcoin/v1/src/trustee.rs
+++ b/xpallets/gateway/bitcoin/v1/src/trustee.rs
@@ -10,12 +10,15 @@ use sp_std::{convert::TryFrom, prelude::*};
 use light_bitcoin::{
     chain::Transaction,
     crypto::dhash160,
-    keys::{Address, Public, Type},
+    keys::{MultiAddress as Address, Public, Type},
     primitives::Bytes,
     script::{Builder, Opcode, Script},
 };
 
-use frame_support::log::{debug, error, info};
+use frame_support::{
+    log::{debug, error, info},
+    traits::Get,
+};
 
 use xp_gateway_bitcoin::extract_output_addr;
 use xpallet_assets::Chain;
@@ -489,6 +492,7 @@ pub(crate) fn create_multi_address<T: Config<I>, I: 'static>(
         kind: Type::P2SH,
         network: Pallet::<T, I>::network_id(),
         hash: dhash160(&redeem_script),
+        chain: T::ChainIdentity::get(),
     };
     let script_bytes: Bytes = redeem_script.into();
     Some(BtcTrusteeAddrInfo {
@@ -556,7 +560,8 @@ fn check_withdraw_tx_impl<T: Config<I>, I: 'static>(
     let btc_network = Pallet::<T, I>::network_id();
     let mut tx_withdraw_list = Vec::new();
     for output in &tx.outputs {
-        let addr = extract_output_addr(&output, btc_network).ok_or("not found addr in this out")?;
+        let addr =
+            extract_output_addr(&output, btc_network, None).ok_or("not found addr in this out")?;
         if addr.hash != hot_trustee_address.hash {
             // expect change to trustee_addr output
             tx_withdraw_list.push((addr, output.value + btc_withdrawal_fee));

--- a/xpallets/gateway/bitcoin/v1/src/tx/mod.rs
+++ b/xpallets/gateway/bitcoin/v1/src/tx/mod.rs
@@ -9,7 +9,7 @@ use sp_std::prelude::*;
 
 use light_bitcoin::{
     chain::Transaction,
-    keys::{Address, DisplayLayout, Network},
+    keys::{DisplayLayout, MultiAddress as Address, Network},
     primitives::{hash_rev, H256},
 };
 

--- a/xpallets/gateway/bitcoin/v1/src/types.rs
+++ b/xpallets/gateway/bitcoin/v1/src/types.rs
@@ -7,9 +7,11 @@ use serde::{Deserialize, Serialize};
 use sp_runtime::RuntimeDebug;
 use sp_std::prelude::*;
 
+use frame_support::traits::Get;
+
 use light_bitcoin::{
     chain::{BlockHeader as BtcHeader, Transaction as BtcTransaction},
-    keys::Address,
+    keys::{Chain, MultiAddress as Address},
     merkle::PartialMerkleTree,
     primitives::{Compact, H256},
 };
@@ -21,6 +23,20 @@ use xp_gateway_bitcoin::BtcTxType;
 /// like: "1Nekoo5VTe7yQQ8WFqrva2UbdyRMVYCP1t" or "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy"
 /// not layout state or public or else.
 pub type BtcAddress = Vec<u8>;
+
+pub struct BtcChain;
+impl Get<Chain> for BtcChain {
+    fn get() -> Chain {
+        Chain::Bitcoin
+    }
+}
+
+pub struct DogeChain;
+impl Get<Chain> for DogeChain {
+    fn get() -> Chain {
+        Chain::Dogecoin
+    }
+}
 
 #[derive(Clone, RuntimeDebug)]
 pub struct BtcRelayedTx {

--- a/xpallets/gateway/common/src/mock.rs
+++ b/xpallets/gateway/common/src/mock.rs
@@ -145,7 +145,7 @@ impl xpallet_gateway_bitcoin::Config for Test {
     type ReferralBinding = ();
     type AddressBinding = ();
     type WeightInfo = ();
-    type ChainIdentity = xpallet_gateway_bitcoin::types::BtcChain;
+    type Chain = xpallet_gateway_bitcoin::types::BtcChain;
 }
 
 pub struct MultisigAddr;

--- a/xpallets/gateway/common/src/mock.rs
+++ b/xpallets/gateway/common/src/mock.rs
@@ -145,6 +145,7 @@ impl xpallet_gateway_bitcoin::Config for Test {
     type ReferralBinding = ();
     type AddressBinding = ();
     type WeightInfo = ();
+    type ChainIdentity = xpallet_gateway_bitcoin::types::BtcChain;
 }
 
 pub struct MultisigAddr;


### PR DESCRIPTION
Cause `Address` cannot parse dogecoin address,  we need to change  `Address` in `RequestInfo` to `MultiAddress`
see https://github.com/chainx-org/btc-relay/blob/d483d546c008a1f5b87ac85cc5b02d9c44ef5233/src/chainx.rs#L117