### PR TITLE
Use DispatchResult for pallet calls

### DIFF
--- a/xpallets/gateway/bitcoin/v1/src/benchmarking.rs
+++ b/xpallets/gateway/bitcoin/v1/src/benchmarking.rs
@@ -2,7 +2,7 @@
 
 use codec::{Decode, Encode};
 use frame_benchmarking::{benchmarks, whitelisted_caller};
-use frame_support::storage::{StorageMap, StorageValue};
+use frame_support::storage::StorageMap;
 use frame_system::RawOrigin;
 use sp_runtime::{AccountId32, SaturatedConversion};
 use sp_std::{collections::btree_map::BTreeMap, prelude::*};

--- a/xpallets/gateway/bitcoin/v1/src/lib.rs
+++ b/xpallets/gateway/bitcoin/v1/src/lib.rs
@@ -150,7 +150,7 @@ pub mod pallet {
             origin: OriginFor<T>,
             withdrawal_id_list: Vec<u32>,
             tx: Vec<u8>,
-        ) -> DispatchResultWithPostInfo {
+        ) -> DispatchResult {
             let from = ensure_signed(origin)?;
             // committer must be in the trustee list
             Self::ensure_trustee(&from)?;
@@ -165,17 +165,14 @@ pub mod pallet {
             );
 
             Self::apply_create_withdraw(from, tx, withdrawal_id_list)?;
-            Ok(().into())
+            Ok(())
         }
 
         /// Trustees sign a withdrawal proposal. If `tx` is None, means this trustee vote to reject
         /// this proposal. If `tx` is Some(), the inner part must be a valid transaction with this
         /// trustee signature.
         #[pallet::weight(<T as Config>::WeightInfo::sign_withdraw_tx())]
-        pub fn sign_withdraw_tx(
-            origin: OriginFor<T>,
-            tx: Option<Vec<u8>>,
-        ) -> DispatchResultWithPostInfo {
+        pub fn sign_withdraw_tx(origin: OriginFor<T>, tx: Option<Vec<u8>>) -> DispatchResult {
             let from = ensure_signed(origin)?;
             Self::ensure_trustee(&from)?;
 
@@ -192,29 +189,23 @@ pub mod pallet {
             );
 
             Self::apply_sig_withdraw(from, tx)?;
-            Ok(().into())
+            Ok(())
         }
 
         /// Dangerous! Be careful to set BestIndex
         #[pallet::weight(<T as Config>::WeightInfo::set_best_index())]
-        pub fn set_best_index(
-            origin: OriginFor<T>,
-            index: BtcHeaderIndex,
-        ) -> DispatchResultWithPostInfo {
+        pub fn set_best_index(origin: OriginFor<T>, index: BtcHeaderIndex) -> DispatchResult {
             ensure_root(origin)?;
             BestIndex::<T>::put(index);
-            Ok(().into())
+            Ok(())
         }
 
         /// Dangerous! Be careful to set ConfirmedIndex
         #[pallet::weight(<T as Config>::WeightInfo::set_confirmed_index())]
-        pub fn set_confirmed_index(
-            origin: OriginFor<T>,
-            index: BtcHeaderIndex,
-        ) -> DispatchResultWithPostInfo {
+        pub fn set_confirmed_index(origin: OriginFor<T>, index: BtcHeaderIndex) -> DispatchResult {
             ensure_root(origin)?;
             ConfirmedIndex::<T>::put(index);
-            Ok(().into())
+            Ok(())
         }
 
         /// Allow root or trustees could remove pending deposits for an address and decide whether
@@ -225,7 +216,7 @@ pub mod pallet {
             origin: OriginFor<T>,
             addr: BtcAddress,
             who: Option<T::AccountId>,
-        ) -> DispatchResultWithPostInfo {
+        ) -> DispatchResult {
             T::TrusteeOrigin::try_origin(origin)
                 .map(|_| ())
                 .or_else(ensure_root)?;
@@ -240,16 +231,16 @@ pub mod pallet {
                 );
                 PendingDeposits::<T>::remove(&addr);
             }
-            Ok(().into())
+            Ok(())
         }
 
         /// Dangerous! remove current withdrawal proposal directly. Please check business logic before
         /// do this operation.
         #[pallet::weight(<T as Config>::WeightInfo::remove_proposal())]
-        pub fn remove_proposal(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
+        pub fn remove_proposal(origin: OriginFor<T>) -> DispatchResult {
             ensure_root(origin)?;
             WithdrawalProposal::<T>::kill();
-            Ok(().into())
+            Ok(())
         }
 
         /// Dangerous! force replace current withdrawal proposal transaction. Please check business
@@ -259,17 +250,14 @@ pub mod pallet {
         /// a new valid transaction which outputs same to current proposal to replace current proposal
         /// transaction.)
         #[pallet::weight(<T as Config>::WeightInfo::force_replace_proposal_tx())]
-        pub fn force_replace_proposal_tx(
-            origin: OriginFor<T>,
-            tx: Vec<u8>,
-        ) -> DispatchResultWithPostInfo {
+        pub fn force_replace_proposal_tx(origin: OriginFor<T>, tx: Vec<u8>) -> DispatchResult {
             T::TrusteeOrigin::try_origin(origin)
                 .map(|_| ())
                 .or_else(ensure_root)?;
             let tx = Self::deserialize_tx(tx.as_slice())?;
             log!(debug, "[force_replace_proposal_tx] new_tx:{:?}", tx);
             Self::force_replace_withdraw_tx(tx)?;
-            Ok(().into())
+            Ok(())
         }
 
         /// Set bitcoin withdrawal fee
@@ -277,12 +265,12 @@ pub mod pallet {
         pub fn set_btc_withdrawal_fee(
             origin: OriginFor<T>,
             #[pallet::compact] fee: u64,
-        ) -> DispatchResultWithPostInfo {
+        ) -> DispatchResult {
             T::TrusteeOrigin::try_origin(origin)
                 .map(|_| ())
                 .or_else(ensure_root)?;
             BtcWithdrawalFee::<T>::put(fee);
-            Ok(().into())
+            Ok(())
         }
 
         /// Set bitcoin deposit limit
@@ -290,12 +278,12 @@ pub mod pallet {
         pub fn set_btc_deposit_limit(
             origin: OriginFor<T>,
             #[pallet::compact] value: u64,
-        ) -> DispatchResultWithPostInfo {
+        ) -> DispatchResult {
             T::TrusteeOrigin::try_origin(origin)
                 .map(|_| ())
                 .or_else(ensure_root)?;
             BtcMinDeposit::<T>::put(value);
-            Ok(().into())
+            Ok(())
         }
     }
 

--- a/xpallets/gateway/bitcoin/v1/src/tests/trustee.rs
+++ b/xpallets/gateway/bitcoin/v1/src/tests/trustee.rs
@@ -1,6 +1,6 @@
 // Copyright 2019-2020 ChainX Project Authors. Licensed under GPL-3.0.
 
-use frame_support::{assert_noop, assert_ok, storage::StorageValue};
+use frame_support::{assert_noop, assert_ok};
 use frame_system::RawOrigin;
 use hex_literal::hex;
 

--- a/xpallets/gateway/bitcoin/v1/src/tests/tx.rs
+++ b/xpallets/gateway/bitcoin/v1/src/tests/tx.rs
@@ -2,7 +2,7 @@
 
 #![allow(non_upper_case_globals)]
 
-use frame_support::{assert_noop, assert_ok, storage::StorageValue};
+use frame_support::{assert_noop, assert_ok};
 use sp_core::crypto::{set_default_ss58_version, Ss58AddressFormat};
 
 use light_bitcoin::{

--- a/xpallets/mining/asset/src/lib.rs
+++ b/xpallets/mining/asset/src/lib.rs
@@ -46,7 +46,7 @@ pub use pallet::*;
 #[frame_support::pallet]
 pub mod pallet {
     use super::*;
-    use frame_support::pallet_prelude::*;
+    use frame_support::{dispatch::DispatchResult, pallet_prelude::*};
     use frame_system::pallet_prelude::*;
 
     #[pallet::config]
@@ -80,7 +80,7 @@ pub mod pallet {
         pub(crate) fn claim(
             origin: OriginFor<T>,
             #[pallet::compact] target: AssetId,
-        ) -> DispatchResultWithPostInfo {
+        ) -> DispatchResult {
             let sender = ensure_signed(origin)?;
 
             ensure!(
@@ -90,7 +90,7 @@ pub mod pallet {
 
             <Self as Claim<T::AccountId>>::claim(&sender, &target)?;
 
-            Ok(().into())
+            Ok(())
         }
 
         #[pallet::weight(<T as Config>::WeightInfo::set_claim_staking_requirement())]
@@ -98,12 +98,12 @@ pub mod pallet {
             origin: OriginFor<T>,
             #[pallet::compact] asset_id: AssetId,
             #[pallet::compact] new: StakingRequirement,
-        ) -> DispatchResultWithPostInfo {
+        ) -> DispatchResult {
             ensure_root(origin)?;
             ClaimRestrictionOf::<T>::mutate(asset_id, |restriction| {
                 restriction.staking_requirement = new;
             });
-            Ok(().into())
+            Ok(())
         }
 
         #[pallet::weight(<T as Config>::WeightInfo::set_claim_frequency_limit())]
@@ -111,12 +111,12 @@ pub mod pallet {
             origin: OriginFor<T>,
             #[pallet::compact] asset_id: AssetId,
             #[pallet::compact] new: T::BlockNumber,
-        ) -> DispatchResultWithPostInfo {
+        ) -> DispatchResult {
             ensure_root(origin)?;
             ClaimRestrictionOf::<T>::mutate(asset_id, |restriction| {
                 restriction.frequency_limit = new;
             });
-            Ok(().into())
+            Ok(())
         }
 
         #[pallet::weight(<T as Config>::WeightInfo::set_asset_power())]
@@ -124,10 +124,10 @@ pub mod pallet {
             origin: OriginFor<T>,
             #[pallet::compact] asset_id: AssetId,
             #[pallet::compact] new: FixedAssetPower,
-        ) -> DispatchResultWithPostInfo {
+        ) -> DispatchResult {
             ensure_root(origin)?;
             FixedAssetPowerOf::<T>::insert(asset_id, new);
-            Ok(().into())
+            Ok(())
         }
     }
 

--- a/xpallets/mining/asset/src/tests.rs
+++ b/xpallets/mining/asset/src/tests.rs
@@ -2,7 +2,6 @@
 
 use frame_support::{
     assert_err, assert_ok,
-    pallet_prelude::DispatchResultWithPostInfo,
     traits::{Get, OnInitialize},
 };
 use frame_system::RawOrigin;
@@ -17,7 +16,7 @@ fn t_system_block_number_inc(number: BlockNumber) {
     System::set_block_number((System::block_number() + number).into());
 }
 
-fn t_bond(who: AccountId, target: AccountId, value: Balance) -> DispatchResultWithPostInfo {
+fn t_bond(who: AccountId, target: AccountId, value: Balance) -> DispatchResult {
     XStaking::bond(Origin::signed(who), target, value)
 }
 

--- a/xpallets/mining/staking/src/tests.rs
+++ b/xpallets/mining/staking/src/tests.rs
@@ -2,15 +2,13 @@
 
 use super::*;
 use crate::mock::*;
-use frame_support::{
-    assert_err, assert_ok, pallet_prelude::DispatchResultWithPostInfo, traits::OnInitialize,
-};
+use frame_support::{assert_err, assert_ok, traits::OnInitialize};
 
 fn t_issue_pcx(to: AccountId, value: Balance) {
     XStaking::mint(&to, value);
 }
 
-fn t_register(who: AccountId, initial_bond: Balance) -> DispatchResultWithPostInfo {
+fn t_register(who: AccountId, initial_bond: Balance) -> DispatchResult {
     let mut referral_id = who.to_string().as_bytes().to_vec();
 
     if referral_id.len() < 2 {
@@ -20,20 +18,15 @@ fn t_register(who: AccountId, initial_bond: Balance) -> DispatchResultWithPostIn
     XStaking::register(Origin::signed(who), referral_id, initial_bond)
 }
 
-fn t_bond(who: AccountId, target: AccountId, value: Balance) -> DispatchResultWithPostInfo {
+fn t_bond(who: AccountId, target: AccountId, value: Balance) -> DispatchResult {
     XStaking::bond(Origin::signed(who), target, value)
 }
 
-fn t_rebond(
-    who: AccountId,
-    from: AccountId,
-    to: AccountId,
-    value: Balance,
-) -> DispatchResultWithPostInfo {
+fn t_rebond(who: AccountId, from: AccountId, to: AccountId, value: Balance) -> DispatchResult {
     XStaking::rebond(Origin::signed(who), from, to, value)
 }
 
-fn t_unbond(who: AccountId, target: AccountId, value: Balance) -> DispatchResultWithPostInfo {
+fn t_unbond(who: AccountId, target: AccountId, value: Balance) -> DispatchResult {
     XStaking::unbond(Origin::signed(who), target, value)
 }
 
@@ -41,7 +34,7 @@ fn t_withdraw_unbonded(
     who: AccountId,
     target: AccountId,
     unbonded_index: UnbondedIndex,
-) -> DispatchResultWithPostInfo {
+) -> DispatchResult {
     XStaking::unlock_unbonded_withdrawal(Origin::signed(who), target, unbonded_index)
 }
 


### PR DESCRIPTION
If the pallet call merely returns `Ok(())`, use the simpler `DispatchResult` instead.