### PR TITLE
Fix docker build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
+        # NOTE: Do not forget to also update the toolchain in Dockerfile when updating the toolchain here.
         toolchain: [nightly-2021-06-29]
 
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL description="The build stage for ChainX. We create the ChainX binary in th
 
 ARG PROFILE=release
 ARG APP=chainx
-ARG RUSTC_VERSION=nightly-2021-03-01
+ARG RUSTC_VERSION=nightly-2021-06-29
 
 WORKDIR /$APP
 


### PR DESCRIPTION
This PR hopefully fixes the docker build, I didn't actually test it locally though :(

Due to the docker build job being extremely slow, it does not run until the PR gets merged. Theoretically the [docker build failure](https://github.com/chainx-org/ChainX/runs/4324208279?check_suite_focus=true) should not happen as long as we use the same rustc version to the one used in GitHub Action and CI is green. I have added a comment in `ci.yml`.

