### PR TITLE
Use the updated session info

### DIFF
--- a/runtime/chainx/src/lib.rs
+++ b/runtime/chainx/src/lib.rs
@@ -112,7 +112,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("chainx"),
     impl_name: create_runtime_str!("chainx-net"),
     authoring_version: 1,
-    spec_version: 18,
+    spec_version: 19,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 4,

--- a/runtime/chainx/src/lib.rs
+++ b/runtime/chainx/src/lib.rs
@@ -112,7 +112,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("chainx"),
     impl_name: create_runtime_str!("chainx-net"),
     authoring_version: 1,
-    spec_version: 17,
+    spec_version: 18,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 4,

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -112,7 +112,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("chainx"),
     impl_name: create_runtime_str!("chainx-dev"),
     authoring_version: 1,
-    spec_version: 18,
+    spec_version: 19,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 4,

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -112,7 +112,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("chainx"),
     impl_name: create_runtime_str!("chainx-dev"),
     authoring_version: 1,
-    spec_version: 17,
+    spec_version: 18,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 4,

--- a/runtime/malan/src/lib.rs
+++ b/runtime/malan/src/lib.rs
@@ -112,7 +112,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("chainx"),
     impl_name: create_runtime_str!("chainx-malan"),
     authoring_version: 1,
-    spec_version: 18,
+    spec_version: 19,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 4,

--- a/runtime/malan/src/lib.rs
+++ b/runtime/malan/src/lib.rs
@@ -112,7 +112,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("chainx"),
     impl_name: create_runtime_str!("chainx-malan"),
     authoring_version: 1,
-    spec_version: 17,
+    spec_version: 18,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 4,

--- a/xpallets/gateway/common/src/lib.rs
+++ b/xpallets/gateway/common/src/lib.rs
@@ -1033,8 +1033,8 @@ impl<T: Config> Pallet<T> {
 
         let trustees = trustee_info
             .0
-            .clone()
             .trustee_list
+            .clone()
             .into_iter()
             .unzip::<_, _, _, Vec<u64>>()
             .0;

--- a/xpallets/gateway/common/src/lib.rs
+++ b/xpallets/gateway/common/src/lib.rs
@@ -364,6 +364,7 @@ pub mod pallet {
                     }
                 });
             } else {
+                let session_info = T::BitcoinTrusteeSessionProvider::trustee_session(session_num)?;
                 let who = ensure_signed(origin)?;
                 ensure!(
                     session_info.trustee_list.iter().any(|n| n.0 == who),

--- a/xpallets/gateway/common/src/lib.rs
+++ b/xpallets/gateway/common/src/lib.rs
@@ -984,22 +984,24 @@ impl<T: Config> Pallet<T> {
     fn alter_trustee_session(
         chain: Chain,
         session_number: u32,
-        new_trustees: Vec<T::AccountId>,
+        session_info: &mut (
+            GenericTrusteeSessionInfo<T::AccountId, T::BlockNumber>,
+            ScriptInfo<T::AccountId>,
+        ),
     ) -> DispatchResult {
-        let mut info = Self::try_generate_session_info(chain, new_trustees)?;
-        let multi_addr = Self::generate_multisig_addr(chain, &info.0)?;
-        info.0 .0.multi_account = Some(multi_addr.clone());
+        let multi_addr = Self::generate_multisig_addr(chain, &session_info.0)?;
+        session_info.0 .0.multi_account = Some(multi_addr.clone());
 
         TrusteeSessionInfoLen::<T>::insert(chain, session_number);
-        TrusteeSessionInfoOf::<T>::insert(chain, session_number, info.0.clone());
+        TrusteeSessionInfoOf::<T>::insert(chain, session_number, session_info.0.clone());
         TrusteeMultiSigAddr::<T>::insert(chain, multi_addr);
         // Remove the information of the previous aggregate public key，Withdrawal is prohibited at this time.
         AggPubkeyInfo::<T>::remove_all(None);
-        for index in 0..info.1.agg_pubkeys.len() {
+        for index in 0..session_info.1.agg_pubkeys.len() {
             AggPubkeyInfo::<T>::insert(
                 chain,
-                &info.1.agg_pubkeys[index],
-                info.1.personal_accounts[index].clone(),
+                &session_info.1.agg_pubkeys[index],
+                session_info.1.personal_accounts[index].clone(),
             );
         }
         TrusteeAdmin::<T>::remove(chain);
@@ -1007,8 +1009,8 @@ impl<T: Config> Pallet<T> {
         Self::deposit_event(Event::<T>::TrusteeSetChanged(
             chain,
             session_number,
-            info.0,
-            info.1.agg_pubkeys.len() as u32,
+            session_info.0.clone(),
+            session_info.1.agg_pubkeys.len() as u32,
         ));
         Ok(())
     }
@@ -1020,7 +1022,8 @@ impl<T: Config> Pallet<T> {
         let session_number = Self::trustee_session_info_len(chain)
             .checked_add(1)
             .unwrap_or(0u32);
-        Self::alter_trustee_session(chain, session_number, new_trustees)
+        let mut session_info = Self::try_generate_session_info(chain, new_trustees)?;
+        Self::alter_trustee_session(chain, session_number, &mut session_info)
     }
 
     fn cancel_trustee_transition_impl(chain: Chain) -> DispatchResult {
@@ -1030,12 +1033,16 @@ impl<T: Config> Pallet<T> {
 
         let trustees = trustee_info
             .0
+            .clone()
             .trustee_list
             .into_iter()
             .unzip::<_, _, _, Vec<u64>>()
             .0;
 
-        Self::alter_trustee_session(chain, session_number, trustees)
+        let mut session_info = Self::try_generate_session_info(chain, trustees)?;
+        session_info.0 = trustee_info;
+
+        Self::alter_trustee_session(chain, session_number, &mut session_info)
     }
 
     pub fn generate_multisig_addr(

--- a/xpallets/gateway/common/src/lib.rs
+++ b/xpallets/gateway/common/src/lib.rs
@@ -352,10 +352,8 @@ pub mod pallet {
             } else {
                 session_num as u32
             };
-            let session_info = T::BitcoinTrusteeSessionProvider::trustee_session(session_num)?;
 
-            let current_session_info = T::BitcoinTrusteeSessionProvider::current_trustee_session()?;
-            if current_session_info == session_info {
+            if session_num == Self::trustee_session_info_len(chain) {
                 T::CouncilOrigin::ensure_origin(origin)?;
                 // update trustee sig record info (update reward weight)
                 TrusteeSessionInfoOf::<T>::mutate(chain, session_num, |info| {

--- a/xpallets/gateway/common/src/tests.rs
+++ b/xpallets/gateway/common/src/tests.rs
@@ -1,13 +1,7 @@
 use frame_system::RawOrigin;
-use sp_std::convert::TryFrom;
 
 use crate::{
-    mock::{
-        bob, charlie, dave, AccountId, BlockNumber, ExtBuilder, Test, XAssets, XGatewayCommon,
-        XGatewayRecords,
-    },
-    trustees::bitcoin::BtcTrusteeAddrInfo,
-    types::TrusteeSessionInfo,
+    mock::{bob, charlie, dave, ExtBuilder, Test, XAssets, XGatewayCommon, XGatewayRecords},
     Pallet, TrusteeSessionInfoLen, TrusteeSessionInfoOf, TrusteeSigRecord,
 };
 use frame_support::assert_ok;
@@ -83,13 +77,7 @@ fn test_claim_not_native_asset_reward() {
             }
         });
 
-        let session_info = XGatewayCommon::trustee_session_info_of(Chain::Bitcoin, 1).unwrap();
-        let info = TrusteeSessionInfo::<AccountId, BlockNumber, BtcTrusteeAddrInfo>::try_from(
-            session_info,
-        )
-        .unwrap();
-
-        assert_ok!(XGatewayCommon::apply_claim_trustee_reward(1, &info));
+        assert_ok!(XGatewayCommon::apply_claim_trustee_reward(1));
 
         assert_eq!(XAssets::usable_balance(&bob(), &X_BTC), 9);
         assert_eq!(XAssets::usable_balance(&charlie(), &X_BTC), 1);


### PR DESCRIPTION
After the current trust signature information is updated, there is no use of the latest trust information to allocate rewards.