### PR TITLE
Prevent transition when proposal processed

### DIFF
--- a/runtime/chainx/src/lib.rs
+++ b/runtime/chainx/src/lib.rs
@@ -1017,11 +1017,11 @@ impl xpallet_gateway_common::Config for Runtime {
     type DetermineMultisigAddress = MultisigProvider;
     type CouncilOrigin =
         pallet_collective::EnsureProportionAtLeast<_2, _3, AccountId, CouncilCollective>;
-    type WithdrawalProposal = XGatewayBitcoin;
     type Bitcoin = XGatewayBitcoin;
     type BitcoinTrustee = XGatewayBitcoin;
     type BitcoinTrusteeSessionProvider = trustees::bitcoin::BtcTrusteeSessionManager<Runtime>;
     type BitcoinTotalSupply = XGatewayBitcoin;
+    type BitcoinWithdrawalProposal = XGatewayBitcoin;
     type WeightInfo = xpallet_gateway_common::weights::SubstrateWeight<Runtime>;
 }
 

--- a/runtime/chainx/src/lib.rs
+++ b/runtime/chainx/src/lib.rs
@@ -1017,6 +1017,7 @@ impl xpallet_gateway_common::Config for Runtime {
     type DetermineMultisigAddress = MultisigProvider;
     type CouncilOrigin =
         pallet_collective::EnsureProportionAtLeast<_2, _3, AccountId, CouncilCollective>;
+    type WithdrawalProposal = XGatewayBitcoin;
     type Bitcoin = XGatewayBitcoin;
     type BitcoinTrustee = XGatewayBitcoin;
     type BitcoinTrusteeSessionProvider = trustees::bitcoin::BtcTrusteeSessionManager<Runtime>;

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -1016,6 +1016,7 @@ impl xpallet_gateway_common::Config for Runtime {
     type DetermineMultisigAddress = MultisigProvider;
     type CouncilOrigin =
         pallet_collective::EnsureProportionAtLeast<_2, _3, AccountId, CouncilCollective>;
+    type WithdrawalProposal = XGatewayBitcoin;
     type Bitcoin = XGatewayBitcoin;
     type BitcoinTrustee = XGatewayBitcoin;
     type BitcoinTrusteeSessionProvider = trustees::bitcoin::BtcTrusteeSessionManager<Runtime>;

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -1016,11 +1016,11 @@ impl xpallet_gateway_common::Config for Runtime {
     type DetermineMultisigAddress = MultisigProvider;
     type CouncilOrigin =
         pallet_collective::EnsureProportionAtLeast<_2, _3, AccountId, CouncilCollective>;
-    type WithdrawalProposal = XGatewayBitcoin;
     type Bitcoin = XGatewayBitcoin;
     type BitcoinTrustee = XGatewayBitcoin;
     type BitcoinTrusteeSessionProvider = trustees::bitcoin::BtcTrusteeSessionManager<Runtime>;
     type BitcoinTotalSupply = XGatewayBitcoin;
+    type BitcoinWithdrawalProposal = XGatewayBitcoin;
     type WeightInfo = xpallet_gateway_common::weights::SubstrateWeight<Runtime>;
 }
 

--- a/runtime/malan/src/lib.rs
+++ b/runtime/malan/src/lib.rs
@@ -1016,6 +1016,7 @@ impl xpallet_gateway_common::Config for Runtime {
     type DetermineMultisigAddress = MultisigProvider;
     type CouncilOrigin =
         pallet_collective::EnsureProportionAtLeast<_2, _3, AccountId, CouncilCollective>;
+    type WithdrawalProposal = XGatewayBitcoin;
     type Bitcoin = XGatewayBitcoin;
     type BitcoinTrustee = XGatewayBitcoin;
     type BitcoinTrusteeSessionProvider = trustees::bitcoin::BtcTrusteeSessionManager<Runtime>;

--- a/runtime/malan/src/lib.rs
+++ b/runtime/malan/src/lib.rs
@@ -1016,11 +1016,11 @@ impl xpallet_gateway_common::Config for Runtime {
     type DetermineMultisigAddress = MultisigProvider;
     type CouncilOrigin =
         pallet_collective::EnsureProportionAtLeast<_2, _3, AccountId, CouncilCollective>;
-    type WithdrawalProposal = XGatewayBitcoin;
     type Bitcoin = XGatewayBitcoin;
     type BitcoinTrustee = XGatewayBitcoin;
     type BitcoinTrusteeSessionProvider = trustees::bitcoin::BtcTrusteeSessionManager<Runtime>;
     type BitcoinTotalSupply = XGatewayBitcoin;
+    type BitcoinWithdrawalProposal = XGatewayBitcoin;
     type WeightInfo = xpallet_gateway_common::weights::SubstrateWeight<Runtime>;
 }
 

--- a/xpallets/gateway/bitcoin/src/lib.rs
+++ b/xpallets/gateway/bitcoin/src/lib.rs
@@ -40,7 +40,10 @@ use chainx_primitives::{AssetId, ReferralId};
 use xp_gateway_common::AccountExtractor;
 use xpallet_assets::{BalanceOf, Chain, ChainT, WithdrawalLimit};
 use xpallet_gateway_common::{
-    traits::{AddressBinding, ReferralBinding, TotalSupply, TrusteeInfoUpdate, TrusteeSession},
+    traits::{
+        AddressBinding, ProposalProvider, ReferralBinding, TotalSupply, TrusteeInfoUpdate,
+        TrusteeSession,
+    },
     trustees::bitcoin::BtcTrusteeAddrInfo,
 };
 use xpallet_support::try_addr;
@@ -602,6 +605,13 @@ pub mod pallet {
 
             let asset_supply = xpallet_assets::Pallet::<T>::total_issuance(&xp_protocol::X_BTC);
             asset_supply.saturating_add(pending_deposits)
+        }
+    }
+
+    impl<T: Config> ProposalProvider for Pallet<T> {
+        type WithdrawalProposal = BtcWithdrawalProposal<T::AccountId>;
+        fn get_withdrawal_proposal() -> Option<Self::WithdrawalProposal> {
+            Self::withdrawal_proposal()
         }
     }
 

--- a/xpallets/gateway/bitcoin/src/mock.rs
+++ b/xpallets/gateway/bitcoin/src/mock.rs
@@ -187,11 +187,11 @@ impl xpallet_gateway_common::Config for Test {
     type Validator = ();
     type DetermineMultisigAddress = ();
     type CouncilOrigin = EnsureSigned<AccountId>;
-    type WithdrawalProposal = XGatewayBitcoin;
     type Bitcoin = XGatewayBitcoin;
     type BitcoinTrustee = XGatewayBitcoin;
     type BitcoinTrusteeSessionProvider = trustees::bitcoin::BtcTrusteeSessionManager<Test>;
     type BitcoinTotalSupply = XGatewayBitcoin;
+    type BitcoinWithdrawalProposal = XGatewayBitcoin;
     type WeightInfo = ();
 }
 

--- a/xpallets/gateway/bitcoin/src/mock.rs
+++ b/xpallets/gateway/bitcoin/src/mock.rs
@@ -187,6 +187,7 @@ impl xpallet_gateway_common::Config for Test {
     type Validator = ();
     type DetermineMultisigAddress = ();
     type CouncilOrigin = EnsureSigned<AccountId>;
+    type WithdrawalProposal = XGatewayBitcoin;
     type Bitcoin = XGatewayBitcoin;
     type BitcoinTrustee = XGatewayBitcoin;
     type BitcoinTrusteeSessionProvider = trustees::bitcoin::BtcTrusteeSessionManager<Test>;

--- a/xpallets/gateway/common/src/lib.rs
+++ b/xpallets/gateway/common/src/lib.rs
@@ -83,9 +83,6 @@ pub mod pallet {
         /// A majority of the council can excute some transactions.
         type CouncilOrigin: EnsureOrigin<Self::Origin>;
 
-        /// Get withdrawal proposal.
-        type WithdrawalProposal: ProposalProvider;
-
         /// Get btc chain info.
         type Bitcoin: ChainT<BalanceOf<Self>>;
 
@@ -107,6 +104,9 @@ pub mod pallet {
         /// When the trust changes, the total supply of btc: total issue + pending deposit. Help
         /// to the allocation of btc withdrawal fees.
         type BitcoinTotalSupply: TotalSupply<BalanceOf<Self>>;
+
+        /// Get btc withdrawal proposal.
+        type BitcoinWithdrawalProposal: ProposalProvider;
 
         /// Weight information for extrinsics in this pallet.
         type WeightInfo: WeightInfo;
@@ -864,7 +864,7 @@ impl<T: Config> Pallet<T> {
         );
 
         ensure!(
-            T::WithdrawalProposal::get_withdrawal_proposal().is_none(),
+            T::BitcoinWithdrawalProposal::get_withdrawal_proposal().is_none(),
             Error::<T>::WithdrawalProposalExist,
         );
 

--- a/xpallets/gateway/common/src/mock.rs
+++ b/xpallets/gateway/common/src/mock.rs
@@ -465,6 +465,7 @@ impl crate::Config for Test {
     type Event = ();
     type Validator = AlwaysValidator;
     type DetermineMultisigAddress = MultisigAddr;
+    type WithdrawalProposal = ();
     type Bitcoin = MockBitcoin<Test>;
     type BitcoinTrustee = MockBitcoin<Test>;
     type BitcoinTrusteeSessionProvider = trustees::bitcoin::BtcTrusteeSessionManager<Test>;

--- a/xpallets/gateway/common/src/mock.rs
+++ b/xpallets/gateway/common/src/mock.rs
@@ -465,12 +465,12 @@ impl crate::Config for Test {
     type Event = ();
     type Validator = AlwaysValidator;
     type DetermineMultisigAddress = MultisigAddr;
-    type WithdrawalProposal = ();
+    type CouncilOrigin = EnsureSigned<AccountId>;
     type Bitcoin = MockBitcoin<Test>;
     type BitcoinTrustee = MockBitcoin<Test>;
     type BitcoinTrusteeSessionProvider = trustees::bitcoin::BtcTrusteeSessionManager<Test>;
-    type CouncilOrigin = EnsureSigned<AccountId>;
     type BitcoinTotalSupply = MockBitcoin<Test>;
+    type BitcoinWithdrawalProposal = ();
     type WeightInfo = ();
 }
 

--- a/xpallets/gateway/common/src/traits.rs
+++ b/xpallets/gateway/common/src/traits.rs
@@ -15,6 +15,19 @@ pub trait ChainProvider {
     fn chain() -> Chain;
 }
 
+pub trait ProposalProvider {
+    type WithdrawalProposal;
+
+    fn get_withdrawal_proposal() -> Option<Self::WithdrawalProposal>;
+}
+
+impl ProposalProvider for () {
+    type WithdrawalProposal = ();
+
+    fn get_withdrawal_proposal() -> Option<Self::WithdrawalProposal> {
+        None
+    }
+}
 pub trait TotalSupply<Balance> {
     fn total_supply() -> Balance;
 }


### PR DESCRIPTION
A transition should not take place when there are withdrawals being processed.