### PR TITLE
Improve xstaking election

### DIFF
--- a/runtime/chainx/src/lib.rs
+++ b/runtime/chainx/src/lib.rs
@@ -1078,6 +1078,7 @@ impl xpallet_mining_staking::Config for Runtime {
     type AssetMining = XMiningAsset;
     type DetermineRewardPotAccount =
         xpallet_mining_staking::SimpleValidatorRewardPotAccountDeterminer<Runtime>;
+    type ValidatorRegistration = Session;
     type WeightInfo = xpallet_mining_staking::weights::SubstrateWeight<Runtime>;
 }
 

--- a/runtime/chainx/src/lib.rs
+++ b/runtime/chainx/src/lib.rs
@@ -36,8 +36,9 @@ use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 
 use frame_system::EnsureRoot;
-use pallet_grandpa::fg_primitives;
-use pallet_grandpa::{AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList};
+use pallet_grandpa::{
+    fg_primitives, AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList,
+};
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use pallet_session::historical as pallet_session_historical;
 use sp_authority_discovery::AuthorityId as AuthorityDiscoveryId;
@@ -362,7 +363,11 @@ impl pallet_grandpa::Config for Runtime {
         GrandpaId,
     )>>::IdentificationTuple;
     type KeyOwnerProofSystem = Historical;
-    type HandleEquivocation = ();
+    type HandleEquivocation = pallet_grandpa::EquivocationHandler<
+        Self::KeyOwnerIdentification,
+        Offences,
+        ReportLongevity,
+    >;
     type WeightInfo = ();
     type MaxAuthorities = MaxAuthorities;
 }
@@ -1218,7 +1223,7 @@ construct_runtime!(
         Offences: pallet_offences::{Pallet, Storage, Event} = 9,
         Historical: pallet_session_historical::{Pallet} = 10,
         Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>} = 11,
-        Grandpa: pallet_grandpa::{Pallet, Call, Storage, Config, Event} = 12,
+        Grandpa: pallet_grandpa::{Pallet, Call, Storage, Config, Event, ValidateUnsigned} = 12,
         ImOnline: pallet_im_online::{Pallet, Call, Storage, Event<T>, ValidateUnsigned, Config<T>} = 13,
         AuthorityDiscovery: pallet_authority_discovery::{Pallet, Config} = 14,
 

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -1077,6 +1077,7 @@ impl xpallet_mining_staking::Config for Runtime {
     type AssetMining = XMiningAsset;
     type DetermineRewardPotAccount =
         xpallet_mining_staking::SimpleValidatorRewardPotAccountDeterminer<Runtime>;
+    type ValidatorRegistration = Session;
     type WeightInfo = xpallet_mining_staking::weights::SubstrateWeight<Runtime>;
 }
 

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -36,8 +36,9 @@ use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 
 use frame_system::EnsureRoot;
-use pallet_grandpa::fg_primitives;
-use pallet_grandpa::{AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList};
+use pallet_grandpa::{
+    fg_primitives, AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList,
+};
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use pallet_session::historical as pallet_session_historical;
 use sp_authority_discovery::AuthorityId as AuthorityDiscoveryId;
@@ -362,7 +363,11 @@ impl pallet_grandpa::Config for Runtime {
         GrandpaId,
     )>>::IdentificationTuple;
     type KeyOwnerProofSystem = Historical;
-    type HandleEquivocation = ();
+    type HandleEquivocation = pallet_grandpa::EquivocationHandler<
+        Self::KeyOwnerIdentification,
+        Offences,
+        ReportLongevity,
+    >;
     type WeightInfo = ();
     type MaxAuthorities = MaxAuthorities;
 }
@@ -1222,7 +1227,7 @@ construct_runtime!(
         Offences: pallet_offences::{Pallet, Storage, Event} = 9,
         Historical: pallet_session_historical::{Pallet} = 10,
         Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>} = 11,
-        Grandpa: pallet_grandpa::{Pallet, Call, Storage, Config, Event} = 12,
+        Grandpa: pallet_grandpa::{Pallet, Call, Storage, Config, Event, ValidateUnsigned} = 12,
         ImOnline: pallet_im_online::{Pallet, Call, Storage, Event<T>, ValidateUnsigned, Config<T>} = 13,
         AuthorityDiscovery: pallet_authority_discovery::{Pallet, Config} = 14,
 

--- a/runtime/malan/src/lib.rs
+++ b/runtime/malan/src/lib.rs
@@ -1077,6 +1077,7 @@ impl xpallet_mining_staking::Config for Runtime {
     type AssetMining = XMiningAsset;
     type DetermineRewardPotAccount =
         xpallet_mining_staking::SimpleValidatorRewardPotAccountDeterminer<Runtime>;
+    type ValidatorRegistration = Session;
     type WeightInfo = xpallet_mining_staking::weights::SubstrateWeight<Runtime>;
 }
 

--- a/runtime/malan/src/lib.rs
+++ b/runtime/malan/src/lib.rs
@@ -36,8 +36,9 @@ use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 
 use frame_system::EnsureRoot;
-use pallet_grandpa::fg_primitives;
-use pallet_grandpa::{AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList};
+use pallet_grandpa::{
+    fg_primitives, AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList,
+};
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use pallet_session::historical as pallet_session_historical;
 use sp_authority_discovery::AuthorityId as AuthorityDiscoveryId;
@@ -362,7 +363,11 @@ impl pallet_grandpa::Config for Runtime {
         GrandpaId,
     )>>::IdentificationTuple;
     type KeyOwnerProofSystem = Historical;
-    type HandleEquivocation = ();
+    type HandleEquivocation = pallet_grandpa::EquivocationHandler<
+        Self::KeyOwnerIdentification,
+        Offences,
+        ReportLongevity,
+    >;
     type WeightInfo = ();
     type MaxAuthorities = MaxAuthorities;
 }
@@ -1222,7 +1227,7 @@ construct_runtime!(
         Offences: pallet_offences::{Pallet, Storage, Event} = 9,
         Historical: pallet_session_historical::{Pallet} = 10,
         Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>} = 11,
-        Grandpa: pallet_grandpa::{Pallet, Call, Storage, Config, Event} = 12,
+        Grandpa: pallet_grandpa::{Pallet, Call, Storage, Config, Event, ValidateUnsigned} = 12,
         ImOnline: pallet_im_online::{Pallet, Call, Storage, Event<T>, ValidateUnsigned, Config<T>} = 13,
         AuthorityDiscovery: pallet_authority_discovery::{Pallet, Config} = 14,
 

--- a/xpallets/mining/asset/src/mock.rs
+++ b/xpallets/mining/asset/src/mock.rs
@@ -7,7 +7,7 @@ use std::{
 
 use frame_support::{
     parameter_types,
-    traits::{GenesisBuild, Get},
+    traits::{GenesisBuild, Get, ValidatorRegistration},
 };
 use sp_core::H256;
 use sp_runtime::{
@@ -240,6 +240,13 @@ impl xp_mining_common::RewardPotAccountFor<AccountId, AccountId>
     }
 }
 
+pub struct Registration;
+impl ValidatorRegistration<u64> for Registration {
+    fn is_registered(_id: &u64) -> bool {
+        true
+    }
+}
+
 impl xpallet_mining_staking::Config for Test {
     type Currency = Balances;
     type Event = Event;
@@ -250,6 +257,7 @@ impl xpallet_mining_staking::Config for Test {
     type SessionInterface = Self;
     type TreasuryAccount = DummyTreasuryAccount;
     type DetermineRewardPotAccount = DummyStakingRewardPotAccountDeterminer;
+    type ValidatorRegistration = Registration;
     type WeightInfo = ();
 }
 

--- a/xpallets/mining/staking/src/election.rs
+++ b/xpallets/mining/staking/src/election.rs
@@ -27,11 +27,14 @@ impl<T: Config> Pallet<T> {
 
     /// Returns true if the (potential) validator is able to join in the election.
     ///
-    /// Two requirements:
+    /// Three requirements:
     /// 1. has the desire to win the election.
     /// 2. meets the threshold of a valid candidate.
+    /// 3. has set session keys by calling pallet_session set_keys.
     fn is_qualified_candidate(who: &T::AccountId) -> bool {
-        Self::is_active(who) && Self::meet_candidate_threshold(who)
+        Self::is_active(who)
+            && Self::meet_candidate_threshold(who)
+            && T::ValidatorRegistration::is_registered(who)
     }
 
     /// Returns true if the candidate meets the minimum candidate threshold.

--- a/xpallets/mining/staking/src/lib.rs
+++ b/xpallets/mining/staking/src/lib.rs
@@ -34,7 +34,10 @@ mod tests;
 use frame_support::{
     ensure,
     log::debug,
-    traits::{Currency, ExistenceRequirement, Get, LockableCurrency, WithdrawReasons},
+    traits::{
+        Currency, ExistenceRequirement, Get, LockableCurrency, ValidatorRegistration,
+        WithdrawReasons,
+    },
 };
 use frame_system::{ensure_root, ensure_signed};
 use sp_runtime::{
@@ -105,7 +108,9 @@ pub mod pallet {
         /// since the workers avoids sending them at the very beginning of the session, assuming
         /// there is a chance the authority will produce a block and they won't be necessary.
         type SessionDuration: Get<Self::BlockNumber>;
-
+        /// Provide information about whether or not some
+        /// validator has been registered with them
+        type ValidatorRegistration: ValidatorRegistration<Self::AccountId>;
         /// Weight information for extrinsics in this pallet.
         type WeightInfo: WeightInfo;
     }

--- a/xpallets/mining/staking/src/mock.rs
+++ b/xpallets/mining/staking/src/mock.rs
@@ -195,6 +195,13 @@ parameter_types! {
     pub const MaximumReferralId: u32 = 12;
 }
 
+pub struct Registration;
+impl ValidatorRegistration<u64> for Registration {
+    fn is_registered(_id: &u64) -> bool {
+        true
+    }
+}
+
 impl Config for Test {
     type Currency = Balances;
     type Event = Event;
@@ -205,6 +212,7 @@ impl Config for Test {
     type SessionInterface = Self;
     type TreasuryAccount = DummyTreasuryAccount;
     type DetermineRewardPotAccount = DummyStakingRewardPotAccountDeterminer;
+    type ValidatorRegistration = Registration;
     type WeightInfo = ();
 }
 


### PR DESCRIPTION
The current qualified validator election sets two conditions
```
1. has the desire to win the election.
2. meets the threshold of a valid candidate.
```

Even if the candidate satisfies the above 2 conditions, the candidate will be discarded by `Session` module, 
because the session keys are not set (call pallet-session::set_keys) (without any prompt log message).

To avoid this low-level error, we add a third condition
```
3. has set session keys by calling pallet_session set_keys.
```

Determine whether this candidate has set session keys by the trait `ValidatorRegistration`, 
